### PR TITLE
Implemented getUser and hiding of personal information

### DIFF
--- a/node_modules/gh-auth/lib/api.js
+++ b/node_modules/gh-auth/lib/api.js
@@ -284,7 +284,7 @@ var registerDeserializeUser = function(cookieSecret) {
 
         // The user is logged in on a regular app
         } else {
-            UsersAPI.getUser(sessionData.userId, function(err, user) {
+            UsersDAO.getUser(sessionData.userId, function(err, user) {
                 if (err) {
                     log().error({'err': err, 'sessionData': sessionData}, 'Failed to retrieve the logged in user from the session cookie');
                     return callback(err);

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -253,6 +253,23 @@ var _setUpModel = function(sequelize) {
             'isGlobalAdmin': function() {
                 return false;
             },
+            'hide': function(ctx) {
+                // There's no need to hide information if the current user is requesting their
+                // own profile or the current user is can administrate the user's application
+                if (ctx.user && (ctx.user.id === this.id || ctx.user.canAdmin(this.AppId))) {
+                    return;
+                }
+
+                // Otherwise we need to hide some information
+                delete this.dataValues.authenticationStrategy;
+                delete this.dataValues.password;
+                delete this.dataValues.calendarToken;
+                delete this.dataValues.email;
+                delete this.dataValues.emailPreference;
+                delete this.dataValues.isAdmin;
+                delete this.dataValues.shibbolethId;
+                delete this.dataValues.termsAndConditions;
+            },
             'toJSON': function() {
                 var json = _.clone(this.dataValues);
 

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -253,9 +253,9 @@ var _setUpModel = function(sequelize) {
             'isGlobalAdmin': function() {
                 return false;
             },
-            'hide': function(ctx) {
+            'hidePersonalInformation': function(ctx) {
                 // There's no need to hide information if the current user is requesting their
-                // own profile or the current user is can administrate the user's application
+                // own profile or the current user can administrate the user's application
                 if (ctx.user && (ctx.user.id === this.id || ctx.user.canAdmin(this.AppId))) {
                     return;
                 }

--- a/node_modules/gh-events/lib/api.js
+++ b/node_modules/gh-events/lib/api.js
@@ -197,6 +197,11 @@ var getEvent = module.exports.getEvent = function(ctx, id, callback) {
             return callback({'code': 401, 'msg': 'This event cannot be retrieved on this application'});
         }
 
+        // Hide organisers their personal information
+        _.each(event.Organisers, function(organiser) {
+            organiser.hide(ctx);
+        });
+
         return callback(null, event);
     });
 };

--- a/node_modules/gh-events/lib/api.js
+++ b/node_modules/gh-events/lib/api.js
@@ -24,6 +24,7 @@ var GroupsAPI = require('gh-groups');
 var GroupsDAO = require('gh-groups/lib/internal/dao');
 var log = require('gh-core/lib/logger').logger('gh-events');
 var SeriesDAO = require('gh-series/lib/internal/dao');
+var UsersAPI = require('gh-users');
 var UsersDAO = require('gh-users/lib/internal/dao');
 var Validator = require('gh-core/lib/validator').Validator;
 
@@ -198,9 +199,7 @@ var getEvent = module.exports.getEvent = function(ctx, id, callback) {
         }
 
         // Hide organisers their personal information
-        _.each(event.Organisers, function(organiser) {
-            organiser.hide(ctx);
-        });
+        UsersAPI.hideUsersPersonalInformation(ctx, event.Organisers);
 
         return callback(null, event);
     });

--- a/node_modules/gh-events/tests/test-organisers.js
+++ b/node_modules/gh-events/tests/test-organisers.js
@@ -22,6 +22,7 @@ var moment = require('moment');
 
 var GroupsTestUtil = require('gh-groups/tests/util');
 var TestsUtil = require('gh-tests');
+var UsersTestsUtil = require('gh-users/tests/util');
 
 var EventsTestUtil = require('./util');
 
@@ -49,19 +50,13 @@ describe('Events', function() {
                         // Get the event
                         EventsTestUtil.assertGetEvent(simon.client, event.id, null, function(event) {
                             assert.strictEqual(event.organisers.length, 2);
+                            var organisersById = _.indexBy(event.organisers, 'id');
 
                             // Verify Nico's information is hidden
-                            var organisersById = _.indexBy(event.organisers, 'id');
-                            assert.strictEqual(organisersById[nico.profile.id].displayName, nico.profile.displayName);
-                            assert.ok(!organisersById[nico.profile.id].calendarToken);
-                            assert.ok(!organisersById[nico.profile.id].email);
-                            assert.ok(!organisersById[nico.profile.id].emailPreference);
+                            UsersTestsUtil.assertUser(organisersById[nico.profile.id], nico.profile, false);
 
                             // Simon his own personal info should be displayed
-                            assert.strictEqual(organisersById[simon.profile.id].calendarToken, simon.profile.calendarToken);
-                            assert.strictEqual(organisersById[simon.profile.id].displayName, simon.profile.displayName);
-                            assert.strictEqual(organisersById[simon.profile.id].email, simon.profile.email);
-                            assert.strictEqual(organisersById[simon.profile.id].emailPreference, simon.profile.emailPreference);
+                            UsersTestsUtil.assertUser(organisersById[simon.profile.id], simon.profile, true);
                             return callback();
                         });
                     });

--- a/node_modules/gh-events/tests/test-organisers.js
+++ b/node_modules/gh-events/tests/test-organisers.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+var _ = require('lodash');
 var assert = require('assert');
 var moment = require('moment');
 
@@ -27,6 +28,46 @@ var EventsTestUtil = require('./util');
 describe('Events', function() {
 
     describe('Organisers', function() {
+
+        /**
+         * Test that verifies that organisers their personal information is hidden
+         */
+        it('verify organisers their personal information is hidden', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2013, 3, false, function(simon, nico, sam) {
+
+                var start = moment().format();
+                var end = moment().add(2, 'hour').format();
+
+                // Create an event
+                EventsTestUtil.assertCreateEvent(simon.client, 'Test event', start, end, null, function(event) {
+
+                    // Add Nico as an organiser
+                    var update = {};
+                    update[nico.profile.id] = true;
+                    EventsTestUtil.assertUpdateEventOrganisers(simon.client, event.id, update, function() {
+
+                        // Get the event
+                        EventsTestUtil.assertGetEvent(simon.client, event.id, null, function(event) {
+                            assert.strictEqual(event.organisers.length, 2);
+
+                            // Verify Nico's information is hidden
+                            var organisersById = _.indexBy(event.organisers, 'id');
+                            assert.strictEqual(organisersById[nico.profile.id].displayName, nico.profile.displayName);
+                            assert.ok(!organisersById[nico.profile.id].calendarToken);
+                            assert.ok(!organisersById[nico.profile.id].email);
+                            assert.ok(!organisersById[nico.profile.id].emailPreference);
+
+                            // Simon his own personal info should be displayed
+                            assert.strictEqual(organisersById[simon.profile.id].calendarToken, simon.profile.calendarToken);
+                            assert.strictEqual(organisersById[simon.profile.id].displayName, simon.profile.displayName);
+                            assert.strictEqual(organisersById[simon.profile.id].email, simon.profile.email);
+                            assert.strictEqual(organisersById[simon.profile.id].emailPreference, simon.profile.emailPreference);
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
 
         /**
          * Test that verifies that organisers can be added and/or removed from events

--- a/node_modules/gh-orgunit/lib/api.js
+++ b/node_modules/gh-orgunit/lib/api.js
@@ -24,7 +24,7 @@ var GroupsAPI = require('gh-groups');
 var GroupsDAO = require('gh-groups/lib/internal/dao');
 var log = require('gh-core/lib/logger').logger('gh-orgunit');
 var SeriesDAO = require('gh-series/lib/internal/dao');
-var UsersAPI = require('gh-users');
+var UsersDAO = require('gh-users/lib/internal/dao');
 var Validator = require('gh-core/lib/validator').Validator;
 
 var OrgUnitAuthz = require('./authz');
@@ -654,7 +654,7 @@ var subscribeOrgUnit = module.exports.subscribeOrgUnit = function(ctx, id, userI
     }
 
     // Ensure the user exists
-    UsersAPI.getUser(userId, function(err, user) {
+    UsersDAO.getUser(userId, function(err, user) {
         if (err) {
             return callback(err);
         }
@@ -713,7 +713,7 @@ var unsubscribeOrgUnit = module.exports.unsubscribeOrgUnit = function(ctx, id, u
     }
 
     // Ensure the user exists
-    UsersAPI.getUser(userId, function(err, user) {
+    UsersDAO.getUser(userId, function(err, user) {
         if (err) {
             return callback(err);
         }

--- a/node_modules/gh-rest/lib/rest/user.js
+++ b/node_modules/gh-rest/lib/rest/user.js
@@ -33,6 +33,21 @@ module.exports = function(client) {
     };
 
     /**
+     * Get a user
+     *
+     * @param  {Number}         id                              The id of the user to retrieve
+     * @param  {Function}       callback                        Standard callback function
+     * @param  {Object}         callback.err                    An error that occurred, if any
+     * @param  {Object}         callback.body                   The JSON response from the REST API
+     * @param  {Response}       callback.response               The response object as returned by requestjs
+     * @see gh-user/lib/rest.js for more information
+     */
+    client.user.getUser = function(id, callback) {
+        var url = '/api/users/' + client.util.encodeURIComponent(id);
+        client._request(url, 'GET', null, null, callback);
+    };
+
+    /**
      * Get all users for an app
      *
      * @param  {Number}         [app]                           The id of the app to get the users for. Defaults to the current app

--- a/node_modules/gh-series/lib/api.js
+++ b/node_modules/gh-series/lib/api.js
@@ -27,6 +27,7 @@ var GroupsAPI = require('gh-groups');
 var GroupsDAO = require('gh-groups/lib/internal/dao');
 var log = require('gh-core/lib/logger').logger('gh-series');
 var OrgUnitDAO = require('gh-orgunit/lib/internal/dao');
+var UsersAPI = require('gh-users');
 var UsersDAO = require('gh-users/lib/internal/dao');
 var Validator = require('gh-core/lib/validator').Validator;
 
@@ -659,9 +660,7 @@ var _getSeriesEvents = function(ctx, id, start, end, limit, offset, upcoming, ca
 
             // Hide organisers their personal information
             _.each(events, function(event) {
-                _.each(event.Organisers, function(organiser) {
-                    organiser.hide(ctx);
-                });
+                UsersAPI.hideUsersPersonalInformation(ctx, event.Organisers);
             });
 
             return callback(null, serie, events);

--- a/node_modules/gh-series/lib/api.js
+++ b/node_modules/gh-series/lib/api.js
@@ -27,7 +27,6 @@ var GroupsAPI = require('gh-groups');
 var GroupsDAO = require('gh-groups/lib/internal/dao');
 var log = require('gh-core/lib/logger').logger('gh-series');
 var OrgUnitDAO = require('gh-orgunit/lib/internal/dao');
-var UsersAPI = require('gh-users');
 var UsersDAO = require('gh-users/lib/internal/dao');
 var Validator = require('gh-core/lib/validator').Validator;
 
@@ -658,6 +657,13 @@ var _getSeriesEvents = function(ctx, id, start, end, limit, offset, upcoming, ca
                 return callback(err);
             }
 
+            // Hide organisers their personal information
+            _.each(events, function(event) {
+                _.each(event.Organisers, function(organiser) {
+                    organiser.hide(ctx);
+                });
+            });
+
             return callback(null, serie, events);
         });
     });
@@ -701,7 +707,7 @@ var subscribeSeries = module.exports.subscribeSeries = function(ctx, id, userId,
     }
 
     // Ensure the user exists
-    UsersAPI.getUser(userId, function(err, user) {
+    UsersDAO.getUser(userId, function(err, user) {
         if (err) {
             return callback(err);
         }
@@ -767,7 +773,7 @@ var unsubscribeSeries = module.exports.unsubscribeSeries = function(ctx, id, use
     }
 
     // Ensure the user exists
-    UsersAPI.getUser(userId, function(err, user) {
+    UsersDAO.getUser(userId, function(err, user) {
         if (err) {
             return callback(err);
         }

--- a/node_modules/gh-series/tests/test-events.js
+++ b/node_modules/gh-series/tests/test-events.js
@@ -494,5 +494,47 @@ describe('Event series', function() {
                 });
             });
         });
+
+        /**
+         * Test that verifies that organisers their personal information is hidden
+         */
+        it('verify organisers their personal information is hidden', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2013, 2, false, function(simon, nico) {
+
+                // Generate a test serie with some events
+                var calendarStart = moment().subtract(1, 'day').format();
+                var calendarEnd = moment().add(30, 'day').format();
+                SeriesTestUtil.generateSerieWithEvents(simon.client, 1, 10, calendarStart, calendarEnd, function(series) {
+                    var serie = series[0];
+                    var event = serie.events[0];
+
+                    // Add Nico as an organiser
+                    var update = {};
+                    update[nico.profile.id] = true;
+                    EventsTestUtil.assertUpdateEventOrganisers(simon.client, event.id, update, function() {
+
+                        // Get the series events
+                        SeriesTestUtil.assertGetSeriesEvents(simon.client, serie.id, null, null, null, null, function(events) {
+
+                            // Assert nico's personal information is hidden
+                            var seenNico = false;
+                            _.each(events.results, function(event) {
+                                _.each(event.organisers, function(organiser) {
+                                    if (_.isObject(organiser) && organiser.id === nico.profile.id) {
+                                        assert.strictEqual(organiser.displayName, nico.profile.displayName);
+                                        assert.ok(!organiser.calendarToken);
+                                        assert.ok(!organiser.email);
+                                        assert.ok(!organiser.emailPreference);
+                                        seenNico = true;
+                                    }
+                                });
+                            });
+                            assert.ok(seenNico);
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
     });
 });

--- a/node_modules/gh-series/tests/test-events.js
+++ b/node_modules/gh-series/tests/test-events.js
@@ -23,6 +23,7 @@ var moment = require('moment');
 var EventsTestUtil = require('gh-events/tests/util');
 var GroupsTestUtil = require('gh-groups/tests/util');
 var TestsUtil = require('gh-tests');
+var UsersTestsUtil = require('gh-users/tests/util');
 
 var SeriesTestUtil = require('./util');
 
@@ -521,10 +522,7 @@ describe('Event series', function() {
                             _.each(events.results, function(event) {
                                 _.each(event.organisers, function(organiser) {
                                     if (_.isObject(organiser) && organiser.id === nico.profile.id) {
-                                        assert.strictEqual(organiser.displayName, nico.profile.displayName);
-                                        assert.ok(!organiser.calendarToken);
-                                        assert.ok(!organiser.email);
-                                        assert.ok(!organiser.emailPreference);
+                                        UsersTestsUtil.assertUser(organiser, nico.profile, false);
                                         seenNico = true;
                                     }
                                 });

--- a/node_modules/gh-users/lib/api.js
+++ b/node_modules/gh-users/lib/api.js
@@ -50,11 +50,24 @@ var init = module.exports.init = function(callback) {
  * @param  {Object}         callback.err                    An error object, if any
  * @param  {User}           callback.user                   The requested user
  */
-var getUser = module.exports.getUser = function(id, callback) {
-    // TODO: id validation
-    // TODO: hide calendarToken
+var getUser = module.exports.getUser = function(ctx, id, callback) {
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'You need to be authenticated in order to get a user'}).isLoggedInUser(ctx);
+    validator.check(id, {'code': 400, 'msg': 'A valid user id must be provided'}).isInt();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
 
-    UsersDAO.getUser(id, callback);
+    UsersDAO.getUser(id, function(err, user) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Hide the user's personal information
+        user.hide(ctx);
+
+        return callback(null, user);
+    });
 };
 
 /**
@@ -90,13 +103,32 @@ var getUsers = module.exports.getUsers = function(ctx, app, query, limit, offset
         return callback({'code': 401, 'msg': 'You are not allowed to search/page users in this application'});
     }
 
+    /*!
+     * Hide personal information from a set of users
+     *
+     * @param  {Object} err   An error object, if any
+     * @param  {User[]} users The users to hide
+     * @api private
+     */
+    var hideUsers = function(err, users) {
+        if (err) {
+            return callback(err);
+        }
+
+        _.each(users, function(user) {
+            user.hide(ctx);
+        });
+
+        return callback(null, users);
+    };
+
     // If a query was specified, search for users
     if (query) {
-        UsersDAO.searchUsers(app, query, limit, offset, callback);
+        UsersDAO.searchUsers(app, query, limit, offset, hideUsers);
 
     // Otherwise we page through the users
     } else {
-        UsersDAO.getUsers(app, limit, offset, callback);
+        UsersDAO.getUsers(app, limit, offset, hideUsers);
     }
 };
 
@@ -209,7 +241,7 @@ var updateUser = module.exports.updateUser = function(ctx, userId, update, callb
     }
 
     // Ensure the user exists
-    getUser(userId, function(err, user) {
+    UsersDAO.getUser(userId, function(err, user) {
         if (err) {
             return callback(err);
         }
@@ -389,7 +421,7 @@ var getUserCalendarRSS = module.exports.getUserCalendarRSS = function(ctx, id, t
  */
 var _getUserCalendar = function(ctx, id, includeContext, token, start, end, callback) {
     // Ensure the user exists
-    getUser(id, function(err, user) {
+    UsersDAO.getUser(id, function(err, user) {
         if (err) {
             return callback(err);
         }
@@ -436,7 +468,7 @@ var resetUserCalendarToken = module.exports.resetUserCalendarToken = function(ct
     }
 
     // Ensure the user exists
-    getUser(id, function(err, user) {
+    UsersDAO.getUser(id, function(err, user) {
         if (err) {
             return callback(err);
         }

--- a/node_modules/gh-users/lib/api.js
+++ b/node_modules/gh-users/lib/api.js
@@ -45,14 +45,15 @@ var init = module.exports.init = function(callback) {
 /**
  * Get a user
  *
- * @param  {Number}         id                              The id of the user to retrieve
- * @param  {Function}       callback                        Standard callback function
- * @param  {Object}         callback.err                    An error object, if any
- * @param  {User}           callback.user                   The requested user
+ * @param  {Context}        ctx                 Standard context object containing the current user and the current application
+ * @param  {Number}         id                  The id of the user to retrieve
+ * @param  {Function}       callback            Standard callback function
+ * @param  {Object}         callback.err        An error object, if any
+ * @param  {User}           callback.user       The requested user
  */
 var getUser = module.exports.getUser = function(ctx, id, callback) {
     var validator = new Validator();
-    validator.check(null, {'code': 401, 'msg': 'You need to be authenticated in order to get a user'}).isLoggedInUser(ctx);
+    validator.check(null, {'code': 401, 'msg': 'Only authenticated users can get a user'}).isLoggedInUser(ctx);
     validator.check(id, {'code': 400, 'msg': 'A valid user id must be provided'}).isInt();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
@@ -61,10 +62,12 @@ var getUser = module.exports.getUser = function(ctx, id, callback) {
     UsersDAO.getUser(id, function(err, user) {
         if (err) {
             return callback(err);
+        } else if (user.AppId !== ctx.app.id && (!ctx.user.canAdmin(user.AppId))) {
+            return callback({'code': 401, 'msg': 'This user cannot be retrieved on this application'});
         }
 
         // Hide the user's personal information
-        user.hide(ctx);
+        user.hidePersonalInformation(ctx);
 
         return callback(null, user);
     });
@@ -89,7 +92,7 @@ var getUsers = module.exports.getUsers = function(ctx, app, query, limit, offset
     offset = GrasshopperUtil.getNumberParam(offset, 0, 0);
 
     var validator = new Validator();
-    validator.check(null, {'code': 401, 'msg': 'You need to be authenticated in order to search/page users'}).isLoggedInUser(ctx);
+    validator.check(null, {'code': 401, 'msg': 'Only authenticated users can search/page users'}).isLoggedInUser(ctx);
     validator.check(app, {'code': 400, 'msg': 'A valid app id must be provided'}).isInt();
     validator.check(limit, {'code': 400, 'msg': 'A valid limit must be provided'}).isInt();
     validator.check(offset, {'code': 400, 'msg': 'A valid offset must be provided'}).isInt();
@@ -106,30 +109,40 @@ var getUsers = module.exports.getUsers = function(ctx, app, query, limit, offset
     /*!
      * Hide personal information from a set of users
      *
-     * @param  {Object} err   An error object, if any
-     * @param  {User[]} users The users to hide
+     * @param  {Object}     err         An error object, if any
+     * @param  {User[]}     users       The users whose personal information to hide
      * @api private
      */
-    var hideUsers = function(err, users) {
+    var done = function(err, users) {
         if (err) {
             return callback(err);
         }
 
-        _.each(users, function(user) {
-            user.hide(ctx);
-        });
+        hideUsersPersonalInformation(ctx, users);
 
         return callback(null, users);
     };
 
     // If a query was specified, search for users
     if (query) {
-        UsersDAO.searchUsers(app, query, limit, offset, hideUsers);
+        UsersDAO.searchUsers(app, query, limit, offset, done);
 
     // Otherwise we page through the users
     } else {
-        UsersDAO.getUsers(app, limit, offset, hideUsers);
+        UsersDAO.getUsers(app, limit, offset, done);
     }
+};
+
+/**
+ * Hide the personal information of a set of users
+ *
+ * @param  {Context}        ctx                 Standard context object containing the current user and the current application
+ * @param  {User[]}         users               The users whose personal information to hide. The modifications will be made inline
+ */
+var hideUsersPersonalInformation = module.exports.hideUsersPersonalInformation = function(ctx, users) {
+    _.each(users, function(user) {
+        user.hidePersonalInformation(ctx);
+    });
 };
 
 /**

--- a/node_modules/gh-users/lib/rest.js
+++ b/node_modules/gh-users/lib/rest.js
@@ -76,7 +76,13 @@ GrassHopper.appRouter.on('get', '/api/users', getUsers);
  * @Return      {User}                                      The requested user
  */
 var getUser = function(req, res) {
-    res.sendStatus(501);
+    UsersAPI.getUser(req.ctx, req.params.id, function(err, user) {
+        if (err) {
+            return res.status(err.code).send(err.msg);
+        }
+
+        return res.status(200).send(user);
+    });
 };
 
 GrassHopper.globalAdminRouter.on('get', '/api/users/:id', getUser);

--- a/node_modules/gh-users/tests/test-search.js
+++ b/node_modules/gh-users/tests/test-search.js
@@ -226,4 +226,67 @@ describe('Users - Search', function() {
             });
         });
     });
+
+    /**
+     * Assert whether personal information should be returned from the get/search users feed
+     *
+     * @param  {Object}         actor                   The object that holds the user and client to fetch the users
+     * @param  {Number}         app                     The id of the application to search in
+     * @param  {String}         [query]                 The query to filter users by
+     * @param  {Boolean}        expectPersonalInfo      Whether user objects should have personal information
+     * @param  {Function}       callback                Standard callback function
+     */
+    var expectUsers = function(actor, app, query, expectPersonalInfo, callback) {
+        UsersTestsUtil.getUsers(actor.client, app, query, null, null, function(users) {
+            _.each(users.results, function(user) {
+                // The display name can always be viewed
+                assert.ok(user.displayName);
+
+                // You can always view your own information
+                if (user.id === actor.profile.id || expectPersonalInfo) {
+                    assert.ok(user.calendarToken);
+                    assert.ok(user.email);
+                    assert.ok(user.emailPreference);
+                } else {
+                    assert.ok(!user.calendarToken);
+                    assert.ok(!user.email);
+                    assert.ok(!user.emailPreference);
+                }
+            });
+            return callback();
+        });
+    };
+
+    /**
+     * Test that verifies that personal information is not returned
+     */
+    it('verify personal information is not returned', function(callback) {
+        TestsUtil.generateTestUsers(global.tests.apps.cam2014, 2, false, function(simon, nico) {
+
+            // Regular users cannot see personal information through search
+            expectUsers(simon, simon.profile.AppId, null, false, function() {
+                expectUsers(simon, simon.profile.AppId, 'user', false, function() {
+
+                    // Application admins can see personal information
+                    expectUsers(global.tests.admins.cam2014, simon.profile.AppId, null, true, function() {
+                        expectUsers(global.tests.admins.cam2014, simon.profile.AppId, 'user', true, function() {
+
+                            // Global admins can see personal information
+                            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+                                var actor = {
+                                    'client': globalAdminClient,
+                                    'profile': {}
+                                };
+                                expectUsers(actor, simon.profile.AppId, null, true, function() {
+                                    expectUsers(actor, simon.profile.AppId, 'user', true, function() {
+                                        return callback();
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
 });

--- a/node_modules/gh-users/tests/test-search.js
+++ b/node_modules/gh-users/tests/test-search.js
@@ -244,13 +244,9 @@ describe('Users - Search', function() {
 
                 // You can always view your own information
                 if (user.id === actor.profile.id || expectPersonalInfo) {
-                    assert.ok(user.calendarToken);
-                    assert.ok(user.email);
-                    assert.ok(user.emailPreference);
+                    UsersTestsUtil.assertUser(user, null, true);
                 } else {
-                    assert.ok(!user.calendarToken);
-                    assert.ok(!user.email);
-                    assert.ok(!user.emailPreference);
+                    UsersTestsUtil.assertUser(user, null, false);
                 }
             });
             return callback();

--- a/node_modules/gh-users/tests/test-users.js
+++ b/node_modules/gh-users/tests/test-users.js
@@ -50,10 +50,7 @@ describe('Users', function() {
             TestsUtil.generateTestUsers(global.tests.apps.cam2014, 1, false, function(simon) {
 
                 UsersTestsUtil.assertGetUser(simon.client, simon.profile.id, function(user) {
-                    assert.strictEqual(user.displayName, simon.profile.displayName);
-                    assert.strictEqual(user.email, simon.profile.email);
-                    assert.strictEqual(user.emailPreference, simon.profile.emailPreference);
-                    assert.strictEqual(user.calendarToken, simon.profile.calendarToken);
+                    UsersTestsUtil.assertUser(user, simon.profile, true);
                     return callback();
                 });
             });
@@ -76,6 +73,31 @@ describe('Users', function() {
         });
 
         /**
+         * Test that verifies authorization when retrieving a user
+         */
+        it('verify authorization when retrieving a user', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2014, 1, false, function(camUser) {
+                TestsUtil.generateTestUsers(global.tests.apps.oxford2013, 1, false, function(oxUser) {
+
+                    // Users from other applications cannot be retrieved by regular users
+                    UsersTestsUtil.assertGetUserFails(camUser.client, oxUser.profile.id, 401, function() {
+
+                        // Users from other applications cannot be retrieved by application admins users
+                        UsersTestsUtil.assertGetUserFails(global.tests.admins.cam2014.client, oxUser.profile.id, 401, function() {
+
+                            // Users from other applications can be retrieved by global admins
+                            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+                                UsersTestsUtil.assertGetUser(globalAdminClient, oxUser.profile.id, function() {
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies that personal information is not returned
          */
         it('verify personal information is not returned', function(callback) {
@@ -83,32 +105,22 @@ describe('Users', function() {
 
                 // Simon can view his own information
                 UsersTestsUtil.assertGetUser(simon.client, simon.profile.id, function(user) {
-                    assert.strictEqual(user.displayName, simon.profile.displayName);
-                    assert.strictEqual(user.email, simon.profile.email);
-                    assert.strictEqual(user.emailPreference, simon.profile.emailPreference);
-                    assert.strictEqual(user.calendarToken, simon.profile.calendarToken);
+                    UsersTestsUtil.assertUser(user, simon.profile, true);
 
                     // Nico can retrieve the profile but not the personal information
                     UsersTestsUtil.assertGetUser(nico.client, simon.profile.id, function(user) {
-                        assert.strictEqual(user.displayName, simon.profile.displayName);
-                        assert.ok(!user.email);
-                        assert.ok(!user.emailPreference);
-                        assert.ok(!user.calendarToken);
+                        UsersTestsUtil.assertUser(user, simon.profile, false);
 
                         // An application administrator from the same app can view Simon's personal information
                         UsersTestsUtil.assertGetUser(global.tests.admins.cam2014.client, simon.profile.id, function(user) {
-                            assert.strictEqual(user.displayName, simon.profile.displayName);
-                            assert.strictEqual(user.email, simon.profile.email);
-                            assert.strictEqual(user.emailPreference, simon.profile.emailPreference);
-                            assert.strictEqual(user.calendarToken, simon.profile.calendarToken);
+                            UsersTestsUtil.assertUser(user, simon.profile, true);
 
-                            // An application administrator from another app can not view Simon's personal information
-                            UsersTestsUtil.assertGetUser(global.tests.admins.oxford2013.client, simon.profile.id, function(user) {
-                                assert.strictEqual(user.displayName, simon.profile.displayName);
-                                assert.ok(!user.email);
-                                assert.ok(!user.emailPreference);
-                                assert.ok(!user.calendarToken);
-                                return callback();
+                            // A global admin can see Simon's personal information
+                            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+                                UsersTestsUtil.assertGetUser(globalAdminClient, simon.profile.id, function(user) {
+                                    UsersTestsUtil.assertUser(user, simon.profile, true);
+                                    return callback();
+                                });
                             });
                         });
                     });

--- a/node_modules/gh-users/tests/test-users.js
+++ b/node_modules/gh-users/tests/test-users.js
@@ -41,6 +41,82 @@ describe('Users', function() {
         });
     });
 
+    describe('Getting a user', function() {
+
+        /**
+         * Test that verifies that a user can be retrieved
+         */
+        it('verify a user can be retrieved', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2014, 1, false, function(simon) {
+
+                UsersTestsUtil.assertGetUser(simon.client, simon.profile.id, function(user) {
+                    assert.strictEqual(user.displayName, simon.profile.displayName);
+                    assert.strictEqual(user.email, simon.profile.email);
+                    assert.strictEqual(user.emailPreference, simon.profile.emailPreference);
+                    assert.strictEqual(user.calendarToken, simon.profile.calendarToken);
+                    return callback();
+                });
+            });
+        });
+
+        /**
+         * Test that verifies validation when retrieving a user
+         */
+        it('verify validation when retrieving a user', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2014, 1, false, function(simon) {
+
+                UsersTestsUtil.assertGetUserFails(simon.client, 'Not a number', 400, function() {
+                    UsersTestsUtil.assertGetUserFails(simon.client, -1, 404, function() {
+                        UsersTestsUtil.assertGetUserFails(simon.client, 234234233, 404, function() {
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that personal information is not returned
+         */
+        it('verify personal information is not returned', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2014, 2, false, function(simon, nico) {
+
+                // Simon can view his own information
+                UsersTestsUtil.assertGetUser(simon.client, simon.profile.id, function(user) {
+                    assert.strictEqual(user.displayName, simon.profile.displayName);
+                    assert.strictEqual(user.email, simon.profile.email);
+                    assert.strictEqual(user.emailPreference, simon.profile.emailPreference);
+                    assert.strictEqual(user.calendarToken, simon.profile.calendarToken);
+
+                    // Nico can retrieve the profile but not the personal information
+                    UsersTestsUtil.assertGetUser(nico.client, simon.profile.id, function(user) {
+                        assert.strictEqual(user.displayName, simon.profile.displayName);
+                        assert.ok(!user.email);
+                        assert.ok(!user.emailPreference);
+                        assert.ok(!user.calendarToken);
+
+                        // An application administrator from the same app can view Simon's personal information
+                        UsersTestsUtil.assertGetUser(global.tests.admins.cam2014.client, simon.profile.id, function(user) {
+                            assert.strictEqual(user.displayName, simon.profile.displayName);
+                            assert.strictEqual(user.email, simon.profile.email);
+                            assert.strictEqual(user.emailPreference, simon.profile.emailPreference);
+                            assert.strictEqual(user.calendarToken, simon.profile.calendarToken);
+
+                            // An application administrator from another app can not view Simon's personal information
+                            UsersTestsUtil.assertGetUser(global.tests.admins.oxford2013.client, simon.profile.id, function(user) {
+                                assert.strictEqual(user.displayName, simon.profile.displayName);
+                                assert.ok(!user.email);
+                                assert.ok(!user.emailPreference);
+                                assert.ok(!user.calendarToken);
+                                return callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
     describe('Updating a user', function() {
 
         /**

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -38,6 +38,41 @@ var assertGetMe = module.exports.assertGetMe = function(client, callback) {
 };
 
 /**
+ * Assert that a user can be retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Number}             id                              The id of the user to retrieve
+ * @param  {Function}           callback                        Standard callback function
+ * @param  {User}               callback.user                   The retrieved user
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetUser = module.exports.assertGetUser = function(client, id, callback) {
+    client.user.getUser(id, function(err, user) {
+        assert.ok(!err);
+        assert.ok(user);
+        return callback(user);
+    });
+};
+
+/**
+ * Assert that a user can not be retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Number}             id                              The id of the user to retrieve
+ * @param  {Number}             code                            The expected HTTP error code
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetUserFails = module.exports.assertGetUserFails = function(client, id, code, callback) {
+    client.user.getUser(id, function(err, user) {
+        assert.ok(err);
+        assert.strictEqual(err.code, code);
+        assert.ok(!user);
+        return callback();
+    });
+};
+
+/**
  * Assert that a user can be updated
  *
  * @param  {RestClient}         client                          The REST client to make the request with

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -22,6 +22,36 @@ var assert = require('assert');
 var TestsUtil = require('gh-tests/lib/util');
 
 /**
+ * Assert that the correct profile fields for a user are returend
+ *
+ * @param  {User}               user                    The user object to verify
+ * @param  {User}               [expectedUser]          The expected user
+ * @param  {Boolean}            canViewAllFields        `true` if all the user profile fields should be present
+ * @throws {AssertionError}                             Error thrown when an assertion failed
+ */
+var assertUser = module.exports.assertUser = function(user, expectedUser, canViewAllFields) {
+    var whiteListedFields = ['AppId', 'createdAt', 'displayName', 'id', 'updatedAt'];
+    if (canViewAllFields) {
+        whiteListedFields = ['AppId', 'authenticationStrategy', 'calendarToken', 'createdAt', 'displayName', 'email',
+                             'emailPreference', 'id', 'isAdmin', 'shibbolethId', 'termsAndConditions', 'updatedAt'];
+    }
+    _.each(user, function(val, key) {
+        // Assert we're allowed to see this field
+        assert.ok(_.contains(whiteListedFields, key), key + ' is not allowed in a public user profile');
+
+        // Assert the field has the correct value
+        if (expectedUser) {
+            assert.strictEqual(val, expectedUser[key]);
+        }
+    });
+
+    // Assert each field is present
+    _.each(whiteListedFields, function(field) {
+        assert.ok(_.has(user, field), field + ' was expected but not found on the user object');
+    });
+};
+
+/**
  * Assert that the me feed can be retrieved
  *
  * @param  {RestClient}         client                          The REST client to make the request with


### PR DESCRIPTION
Supports the REST.getUser logic. A `hide` function is added to each
`User` instance which will hide personal information from users who are
not allowed to see it.