### PR TITLE
Only retrieve that data we really need when getting a user’s calendar

### DIFF
--- a/node_modules/gh-users/lib/internal/dao.js
+++ b/node_modules/gh-users/lib/internal/dao.js
@@ -370,20 +370,26 @@ var getUserCalendar = module.exports.getUserCalendar = function(user, includeCon
         dateTimeFilter.end = {'lte': end};
     }
 
+    // This query fetches such a massive amount of data, that the CPU usage
+    // goes through the roof when Sequelize serialises it. To minimise this,
+    // we retrieve only those columns we really need
+    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'organiserOther', 'updatedAt'];
+    var userFields = ['id', 'displayName'];
+
     var options = {
         // Adding `required` into the model inclusions forces Sequelize to use a
         // `left outer join` to connect the Serie/Events. If these were to be omitted,
         // Sequelize would use an `inner join` which would always result in 0 rows
         'include': [
             {'model': DB.CalendarSeries, 'required': false, 'include': [
-                {'model': DB.Serie, 'required': false, 'limit': null, 'include': [
-                    {'model': DB.Event, 'where': dateTimeFilter, 'required': false, 'include': [
-                        {'model': DB.User, 'as': 'Organisers', 'required': false}
+                {'model': DB.Serie, 'required': false, 'limit': null, 'attributes': ['id'], 'include': [
+                    {'model': DB.Event, 'where': dateTimeFilter, 'required': false, 'attributes': eventFields, 'include': [
+                        {'model': DB.User, 'as': 'Organisers', 'required': false, 'attributes': userFields}
                     ]}
                 ]}
             ]},
-            {'model': DB.Event, 'where': dateTimeFilter, 'required': false, 'include': [
-                {'model': DB.User, 'as': 'Organisers', 'required': false}
+            {'model': DB.Event, 'where': dateTimeFilter, 'required': false, 'attributes': eventFields, 'include': [
+                {'model': DB.User, 'as': 'Organisers', 'required': false, 'attributes': userFields}
             ]}
         ],
 
@@ -394,9 +400,8 @@ var getUserCalendar = module.exports.getUserCalendar = function(user, includeCon
 
     // Only join the organisational units when required
     if (includeContext) {
-        options.include[0].include.push({'model': DB.OrgUnit, 'required': false});
+        options.include[0].include.push({'model': DB.OrgUnit, 'required': false, 'attributes': ['id', 'ParentId', 'displayName', 'type']});
     }
-
     user.getCalendar(options).complete(function(err, calendar) {
         if (err) {
             log().error({'err': err, 'user': user.id}, 'Could not get a user\'s calendar');

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -195,6 +195,20 @@ var assertGetUserCalendar = module.exports.assertGetUserCalendar = function(clie
             });
         }
 
+        // Assert only the required information is returned
+        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context'];
+        var allowedContextKeys = ['id', 'ParentId', 'displayName', 'type'];
+        _.each(calendar.results, function(event) {
+            _.each(event, function(val, key) {
+                assert.ok(_.contains(allowedEventKeys, key), key + ' is not allowed as an event property in a calendar');
+            });
+            if (event.context) {
+                _.each(event.context, function(val, key) {
+                    assert.ok(_.contains(allowedContextKeys, key), key + ' is not allowed as an event\'s context property in a calendar');
+                });
+            }
+        });
+
         return callback(calendar);
     });
 };


### PR DESCRIPTION
Getting a calendar involves getting a ton of data from postgres and munging it in Sequelize. To avoid wasting cycles on stuff that we don't need, this query only selects those columns we actually need. 

This brought a massive improvement when doing performance tests. I will be revisiting the performance tests and try and build up a more realistic scenario and report some proper numbers back.