### PR TITLE
Added an `academicYear` field to the config

### DIFF
--- a/node_modules/gh-config/lib/api.js
+++ b/node_modules/gh-config/lib/api.js
@@ -230,10 +230,18 @@ var updateConfig = module.exports.updateConfig = function(ctx, appId, update, ca
     validator.check(_.keys(update).length, {'code': 400, 'msg': 'At least one config field needs to be specified'}).min(1);
     _.each(update, function(val, key) {
         validator.check(key, {'code': 400, 'msg': 'Unknown config field'}).isIn(ConfigDAO.EDITABLE_FIELDS);
+
         // Config fields that start with `allow` or `enable` should be boolean values
         if (key.indexOf('allow') === 0 || key.indexOf('enable') === 0) {
             val = GrasshopperUtil.getBooleanParam(val);
             validator.check(null, {'code': 400, 'msg': 'Boolean value expected for ' + key}).isBoolean(val);
+            update[key] = val;
+        }
+
+        // A valid integer must be provided for the `academic year` config field
+        if (key === 'academicYear') {
+            val = GrasshopperUtil.getNumberParam(val);
+            validator.check(val, {'code': 400, 'msg': 'Integer value expected for ' + key}).isInt();
             update[key] = val;
         }
     });

--- a/node_modules/gh-config/lib/internal/dao.js
+++ b/node_modules/gh-config/lib/internal/dao.js
@@ -24,7 +24,7 @@ var log = require('gh-core/lib/logger').logger('gh-config');
 // The editable fields
 var fields = ['allowLocalAccountCreation', 'enableLocalAuth', 'enableShibbolethAuth', 'shibIdpEntityId',
               'shibExternalIdAttributes', 'shibMapDisplayname', 'shibMapEmail', 'allowUserEventCreation',
-              'allowUserSerieCreation', 'enableGoogleAnalytics', 'googleAnalyticsTrackingId'];
+              'allowUserSerieCreation', 'enableGoogleAnalytics', 'googleAnalyticsTrackingId', 'academicYear'];
 module.exports.EDITABLE_FIELDS = fields;
 
 

--- a/node_modules/gh-config/lib/restmodel.js
+++ b/node_modules/gh-config/lib/restmodel.js
@@ -19,7 +19,8 @@
 /**
  * @RESTModel Config
  *
- * @Required  [allowLocalAccountCreation,allowUserEventCreation,allowUserSerieCreation,enableLocalAuth,enableShibbolethAuth,enableGoogleAnalytics,googleAnalyticsTrackingId]
+ * @Required  [academicYear,allowLocalAccountCreation,allowUserEventCreation,allowUserSerieCreation,enableLocalAuth,enableShibbolethAuth,enableGoogleAnalytics,googleAnalyticsTrackingId]
+ * @Property  {Number}                  academicYear                        The academic year for an application
  * @Property  {Boolean}                 allowLocalAccountCreation           Whether or not local accounts can be created
  * @Property  {Boolean}                 allowUserEventCreation              Whether or not regular users can create events
  * @Property  {Boolean}                 allowUserSerieCreation              Whether or not regular users can create series

--- a/node_modules/gh-config/tests/test-config.js
+++ b/node_modules/gh-config/tests/test-config.js
@@ -137,7 +137,11 @@ describe('Config', function() {
 
                                             // Incorrect value for boolean fields
                                             ConfigTestsUtil.assertUpdateConfigFails(globalAdminClient, app.id, {'enableLocalAuth': 'Not a boolean'}, 400, function() {
-                                                return callback();
+
+                                                // Incorrect value for integer field
+                                                ConfigTestsUtil.assertUpdateConfigFails(globalAdminClient, app.id, {'academicYear': 'Not a number'}, 400, function() {
+                                                    return callback();
+                                                });
                                             });
                                         });
                                     });

--- a/node_modules/gh-config/tests/util.js
+++ b/node_modules/gh-config/tests/util.js
@@ -37,6 +37,7 @@ var assertGetConfig = module.exports.assertGetConfig = function(client, appId, e
         assert.ok(config);
 
         // Assert the following config values always return
+        assert.ok(_.has(config, 'academicYear'));
         assert.ok(_.has(config, 'allowLocalAccountCreation'));
         assert.ok(_.has(config, 'allowUserSerieCreation'));
         assert.ok(_.has(config, 'enableLocalAuth'));

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -602,6 +602,7 @@ var _setUpModel = function(sequelize) {
      * @property {Boolean}      allowUserSerieCreation              Whether or not regular users can create series
      * @property {Boolean}      enableGoogleAnalytics               Whether or not Google Analytics should be enabled for this application
      * @property {Boolean}      googleAnalyticsTrackingId           The Google Analytics tracking identifier
+     * @property {String}       academicYear                        The academic year for an application
      * @property {App}          app                                 The application with which the configuration is associated
      */
     var Config = module.exports.Config = sequelize.define('Config', {
@@ -654,6 +655,11 @@ var _setUpModel = function(sequelize) {
         'googleAnalyticsTrackingId': {
             'type': Sequelize.TEXT,
             'defaultValue': ''
+        },
+        'academicYear': {
+            'type': Sequelize.INTEGER,
+            'defaultValue': null,
+            'allowNull': true
         },
         'AppId': {
             'type': Sequelize.INTEGER,


### PR DESCRIPTION
We need to know what the term is for a given application so the UI can display the correct default calendar views/get the correct dates.