### PR TITLE
Missing event metadata in ics feeds

### DIFF
--- a/node_modules/gh-calendar/lib/model.js
+++ b/node_modules/gh-calendar/lib/model.js
@@ -19,7 +19,7 @@
 /**
  * A model that contains the information to describe a calendar
  *
- * @param  {String}     host            The hostname on which the calendar is hosted
+ * @param  {App}        app             The application the calendar belongs to
  * @param  {String}     displayName     The name of the calendar
  * @param  {String}     [description]   The description of the calendar
  * @param  {String}     organisation    The organisation that owns the calendar
@@ -27,9 +27,9 @@
  * @param  {String}     editor          The name of the person who last editted the calendar
  * @param  {Date}       lastModified    The timestamp when the calendar was last modified
  */
-var CalendarInfo = module.exports.CalendarInfo = function(host, displayName, description, organisation, link, editor, lastModified) {
+var CalendarInfo = module.exports.CalendarInfo = function(app, displayName, description, organisation, link, editor, lastModified) {
     return {
-        'host': host,
+        'app': app,
         'displayName': displayName,
         'description': description,
         'organisation': organisation,

--- a/node_modules/gh-calendar/lib/util.js
+++ b/node_modules/gh-calendar/lib/util.js
@@ -72,7 +72,12 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
 
         // Only add the notes if there are any
         if (event.notes) {
-            description += '\n\n' + event.notes;
+            // Add 2 line-breaks before the notes only if there's already some text in the description
+            if (description) {
+                description += '\n\n';
+            }
+
+            description += event.notes;
         }
         var vevent = new VEvent({
             'startDate': event.start,

--- a/node_modules/gh-calendar/lib/util.js
+++ b/node_modules/gh-calendar/lib/util.js
@@ -49,36 +49,27 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
         if (event.type) {
             description += event.type;
         }
-
-        // Get the organisers as simple strings. Ensure they are sorted so the iCal feed
-        // doesn't change between fetches as they will be added to the description of each event
-        var organisers = _.chain(event.organisers || [])
-            .sort()
-            .map(function(organiser) {
-                if (_.isString(organiser)) {
-                    return organiser;
-                } else {
-                    return organiser.displayName;
-                }
-            })
-            .value();
-        if (!_.isEmpty(organisers)) {
-            // We add a space if a type was added to the description previously
-            if (description) {
-                description += ' ';
-            }
-            description += 'with ' + organisers.join(', ');
+        if (!_.isEmpty(event.organisers)) {
+            var organisers = _.chain(event.organisers)
+                .sort()
+                .map(function(organiser) {
+                    if (_.isString(organiser)) {
+                        return organiser;
+                    } else {
+                        return organiser.displayName;
+                    }
+                })
+                .value()
+                .join(', ');
+            description += ' with ' + organisers;
         }
-
-        // Only add the notes if there are any
         if (event.notes) {
-            // Add 2 line-breaks before the notes only if there's already some text in the description
-            if (description) {
-                description += '\n\n';
-            }
-
-            description += event.notes;
+            description += '\n\n' + event.notes;
         }
+
+        // Trim any leading or trailing white space
+        description = description.trim();
+
         var vevent = new VEvent({
             'startDate': event.start,
             'endDate': event.end,

--- a/node_modules/gh-calendar/lib/util.js
+++ b/node_modules/gh-calendar/lib/util.js
@@ -37,13 +37,51 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
 
     // Convert each Grasshopper event to an ical VEvent and add it to the calendar
     _.each(events, function(event) {
+        // Get the organisers as simple strings. Ensure they are sorted so the iCal
+        // feed doesn't change between fetches
+        var organisers = _.chain(event.organisers || [])
+            .sort()
+            .map(function(organiser) {
+                if (_.isString(organiser)) {
+                    return organiser;
+                } else {
+                    return organiser.displayName;
+                }
+            })
+            .value();
+
+        // The description of the iCal event depends on the type of application
+        // and how many organisers / speakers there are
+        var description = '';
+        if (calendarInfo.app && calendarInfo.app.type === 'timetable') {
+            if (organisers.length == 1) {
+                description = 'Lecturer: ';
+            } else {
+                description = 'Lecturers: ';
+            }
+        } else {
+            if (organisers.length == 1) {
+                description = 'Speaker: ';
+            } else {
+                description = 'Speakers: ';
+            }
+        }
+        description += organisers.join(', ') + '\n';
+
+        // Add a type and/or description if they are defined
+        if (event.type) {
+            description += 'Type: ' + event.type;
+        }
+        if (event.notes) {
+            description += '\n\n' + event.notes;
+        }
         var vevent = new VEvent({
             'startDate': event.start,
             'endDate': event.end,
             'created': event.createdAt,
             'stampDate': event.updatedAt,
             'summary': event.displayName,
-            'description': event.organiser,
+            'description': description,
             'location': event.location,
             'uid': event.id
         });
@@ -114,7 +152,7 @@ var eventsToRSS = module.exports.eventsToRSS = function(calendarInfo, events) {
  * @api private
  */
 var _createRSSLink = function(calendarInfo, event) {
-    return 'https://' + calendarInfo.host + '/events/' + event.id;
+    return 'https://' + calendarInfo.app.host + '/events/' + event.id;
 };
 
 /**

--- a/node_modules/gh-calendar/lib/util.js
+++ b/node_modules/gh-calendar/lib/util.js
@@ -37,8 +37,8 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
 
     // Convert each Grasshopper event to an ical VEvent and add it to the calendar
     _.each(events, function(event) {
-        // Get the organisers as simple strings. Ensure they are sorted so the iCal
-        // feed doesn't change between fetches
+        // Get the organisers as simple strings. Ensure they are sorted so the iCal feed
+        // doesn't change between fetches as they will be added to the description of each event
         var organisers = _.chain(event.organisers || [])
             .sort()
             .map(function(organiser) {
@@ -53,22 +53,24 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
         // The description of the iCal event depends on the type of application
         // and how many organisers / speakers there are
         var description = '';
-        if (calendarInfo.app && calendarInfo.app.type === 'timetable') {
-            if (organisers.length == 1) {
-                description = 'Lecturer: ';
+        if (!_.isEmpty(organisers)) {
+            if (calendarInfo.app && calendarInfo.app.type === 'timetable') {
+                if (organisers.length == 1) {
+                    description = 'Lecturer: ';
+                } else {
+                    description = 'Lecturers: ';
+                }
             } else {
-                description = 'Lecturers: ';
+                if (organisers.length == 1) {
+                    description = 'Speaker: ';
+                } else {
+                    description = 'Speakers: ';
+                }
             }
-        } else {
-            if (organisers.length == 1) {
-                description = 'Speaker: ';
-            } else {
-                description = 'Speakers: ';
-            }
+            description += organisers.join(', ') + '\n';
         }
-        description += organisers.join(', ') + '\n';
 
-        // Add a type and/or description if they are defined
+        // Add a type and/or notes if they are defined
         if (event.type) {
             description += 'Type: ' + event.type;
         }

--- a/node_modules/gh-calendar/lib/util.js
+++ b/node_modules/gh-calendar/lib/util.js
@@ -37,6 +37,19 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
 
     // Convert each Grasshopper event to an ical VEvent and add it to the calendar
     _.each(events, function(event) {
+        // The description of the iCal event is a concatenation of:
+        //  - The type
+        //  - The organisers
+        //  - The notes
+        // As all of these fields are optional we need to ensure we don't end up with
+        // stringified `null` entries or blank lines
+        var description = '';
+
+        // Only add the type is there is any
+        if (event.type) {
+            description += event.type;
+        }
+
         // Get the organisers as simple strings. Ensure they are sorted so the iCal feed
         // doesn't change between fetches as they will be added to the description of each event
         var organisers = _.chain(event.organisers || [])
@@ -49,31 +62,15 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
                 }
             })
             .value();
-
-        // The description of the iCal event depends on the type of application
-        // and how many organisers / speakers there are
-        var description = '';
         if (!_.isEmpty(organisers)) {
-            if (calendarInfo.app && calendarInfo.app.type === 'timetable') {
-                if (organisers.length == 1) {
-                    description = 'Lecturer: ';
-                } else {
-                    description = 'Lecturers: ';
-                }
-            } else {
-                if (organisers.length == 1) {
-                    description = 'Speaker: ';
-                } else {
-                    description = 'Speakers: ';
-                }
+            // We add a space if a type was added to the description previously
+            if (description) {
+                description += ' ';
             }
-            description += organisers.join(', ') + '\n';
+            description += 'with ' + organisers.join(', ');
         }
 
-        // Add a type and/or notes if they are defined
-        if (event.type) {
-            description += 'Type: ' + event.type;
-        }
+        // Only add the notes if there are any
         if (event.notes) {
             description += '\n\n' + event.notes;
         }

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -475,11 +475,11 @@ var _setUpModel = function(sequelize) {
      * @property  {String}      description         The description of the event
      * @property  {String}      displayName         The name of the event
      * @property  {Date}        end                 The timestamp at which the event ends
-     * @property  {String}      image               The path to an image for the event
-     * @property  {String}      location            The location of the event
-     * @property  {String}      notes               The notes for the event
+     * @property  {String}      [image]             The path to an image for the event
+     * @property  {String}      [location]          The location of the event
+     * @property  {String}      [notes]             The notes for the event
      * @property  {Date}        start               The timestamp at which the event starts
-     * @property  {String}      type                The type of the event
+     * @property  {String}      [type]              The type of the event
      * @property  {String}      [organiserOther]    The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
      */
     var Event = module.exports.Event = sequelize.define('Event', {
@@ -488,11 +488,17 @@ var _setUpModel = function(sequelize) {
             'type': Sequelize.STRING,
             'allowNull': false
         },
-        'end': Sequelize.DATE,
+        'end': {
+            'type': Sequelize.DATE,
+            'allowNull': false
+        },
         'image': Sequelize.STRING,
         'location': Sequelize.STRING,
         'notes': Sequelize.TEXT,
-        'start': Sequelize.DATE,
+        'start': {
+            'type': Sequelize.DATE,
+            'allowNull': false
+        },
         'type': Sequelize.STRING,
         'organiserOther': {
             'type': Sequelize.TEXT,

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -479,6 +479,7 @@ var _setUpModel = function(sequelize) {
      * @property  {String}      location            The location of the event
      * @property  {String}      notes               The notes for the event
      * @property  {Date}        start               The timestamp at which the event starts
+     * @property  {String}      type                The type of the event
      * @property  {String}      [organiserOther]    The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
      */
     var Event = module.exports.Event = sequelize.define('Event', {
@@ -492,6 +493,7 @@ var _setUpModel = function(sequelize) {
         'location': Sequelize.STRING,
         'notes': Sequelize.TEXT,
         'start': Sequelize.DATE,
+        'type': Sequelize.STRING,
         'organiserOther': {
             'type': Sequelize.TEXT,
             'set': function(val) {

--- a/node_modules/gh-events/lib/api.js
+++ b/node_modules/gh-events/lib/api.js
@@ -71,7 +71,6 @@ var createEvent = module.exports.createEvent = function(ctx, appId, displayName,
     // Ensure that the app id is a valid number
     appId = GrasshopperUtil.getNumberParam(appId);
 
-    // TODO: Validate serie if any
     var validator = new Validator();
     validator.check(appId, {'code': 400, 'msg': 'A valid application id must be provided'}).isInt();
     validator.check(displayName, {'code': 400, 'msg': 'A valid displayName must be provided'}).isShortString();

--- a/node_modules/gh-events/lib/api.js
+++ b/node_modules/gh-events/lib/api.js
@@ -58,6 +58,7 @@ var EventsAPI = module.exports = new events.EventEmitter();
  * @param  {String[]}       [opts.organiserOther]       The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
  * @param  {Number[]}       [opts.organiserUsers]       The id(s) of the recognised user(s) that organise the event
  * @param  {Number[]}       [opts.series]               The id(s) of the serie(s) that the event belongs to
+ * @param  {String}         [opts.type]                 The type of the event
  * @param  {Function}       callback                    Standard callback function
  * @param  {Object}         callback.err                An error object, if any
  * @param  {Event}          callback.event              The created event
@@ -114,6 +115,9 @@ var createEvent = module.exports.createEvent = function(ctx, appId, displayName,
             opts.organiserUsers[index] = GrasshopperUtil.getNumberParam(userId);
             validator.check(userId, {'code': 400, 'msg': 'An individual organiser user should be specified by its id'}).isInt();
         });
+    }
+    if (opts.type) {
+        validator.check(opts.type, {'code': 400, 'msg': 'A type can be at most 255 characters long'}).isShortString();
     }
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
@@ -218,6 +222,7 @@ var getEvent = module.exports.getEvent = function(ctx, id, callback) {
  * @param  {Number}         [update.group]              Updated id of the group that can manage the event
  * @param  {String}         [update.notes]              Updated notes for the event
  * @param  {String}         [update.start]              Updated timestamp (ISO 8601) at which the event starts
+ * @param  {String}         [update.type]               Updated type for the event
  * @param  {Function}       callback                    Standard callback function
  * @param  {Object}         callback.err                An error object, if any
  * @param  {Event}          callback.event              The updated event
@@ -249,6 +254,9 @@ var updateEvent = module.exports.updateEvent = function(ctx, id, update, callbac
     }
     if (update.notes) {
         validator.check(update.notes, {'code': 400, 'msg': 'Notes can be at most 10000 characters long'}).isLongString();
+    }
+    if (update.type) {
+        validator.check(update.type, {'code': 400, 'msg': 'A type can be at most 255 characters long'}).isShortString();
     }
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());

--- a/node_modules/gh-events/lib/internal/dao.js
+++ b/node_modules/gh-events/lib/internal/dao.js
@@ -36,6 +36,7 @@ var log = require('gh-core/lib/logger').logger('gh-events');
  * @param  {String}         [opts.notes]                The notes for the event
  * @param  {String[]}       [opts.organiserOther]       The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
  * @param  {Number[]}       [opts.organiserUsers]       The id(s) of the recognised user(s) that organise the event
+ * @param  {Number[]}       [opts.series]               The id(s) of the serie(s) that the event belongs to
  * @param  {String}         [opts.type]                 The type of the event
  */
 var createEvent = module.exports.createEvent = function(appId, displayName, start, end, opts, callback) {

--- a/node_modules/gh-events/lib/internal/dao.js
+++ b/node_modules/gh-events/lib/internal/dao.js
@@ -36,6 +36,7 @@ var log = require('gh-core/lib/logger').logger('gh-events');
  * @param  {String}         [opts.notes]                The notes for the event
  * @param  {String[]}       [opts.organiserOther]       The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
  * @param  {Number[]}       [opts.organiserUsers]       The id(s) of the recognised user(s) that organise the event
+ * @param  {String}         [opts.type]                 The type of the event
  */
 var createEvent = module.exports.createEvent = function(appId, displayName, start, end, opts, callback) {
     // TODO: Transactions
@@ -48,7 +49,8 @@ var createEvent = module.exports.createEvent = function(appId, displayName, star
         'location': opts.location,
         'notes': opts.notes,
         'organiserOther': opts.organiserOther,
-        'start': start
+        'start': start,
+        'type': opts.type
     };
     DB.Event.create(event).complete(function(err, event) {
         if (err) {

--- a/node_modules/gh-events/lib/rest.js
+++ b/node_modules/gh-events/lib/rest.js
@@ -121,14 +121,14 @@ GrassHopper.globalAdminRouter.on('post', '/api/events', createEvent);
  * @Method      POST
  * @Path        /events/{id}
  * @PathParam   {number}                id                  The id of the event to update
- * @FormParam   {string}                [description]       Updated event description
- * @FormParam   {string}                [displayName]       Updated event name
+ * @FormParam   {string}                [description]       The updated event description
+ * @FormParam   {string}                [displayName]       The updated event name
  * @FormParam   {string}                [end]               The updated timestamp (ISO 8601) at which the event ends
- * @FormParam   {string}                [location]          The updatedlocation of the event
- * @FormParam   {group}                 [group]             Updated id of the group that can manage the event
+ * @FormParam   {string}                [location]          The updated event location
+ * @FormParam   {group}                 [group]             The updated id of the group that can manage the event
  * @FormParam   {string}                [notes]             The updated notes for the event
  * @FormParam   {string}                [start]             The updated timestamp (ISO 8601) at which the event starts
- * @FormParam   {string}                [type]              Updated event type
+ * @FormParam   {string}                [type]              The updated event type
  * @Return      {Event}                                     The updated event
  */
 var updateEvent = function(req, res) {

--- a/node_modules/gh-events/lib/rest.js
+++ b/node_modules/gh-events/lib/rest.js
@@ -87,6 +87,7 @@ GrassHopper.appRouter.on('get', '/api/events/:id', getEvent);
  * @FormParam   {string[]}          [organiserOther]    The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
  * @FormParam   {number[]}          [organiserUsers]    The id(s) of the recognised user(s) that organise the event
  * @FormParam   {number[]}          [series]            The id(s) of the serie(s) that the event belongs to
+ * @FormParam   {string}            [type]              The type of the event
  * @Return      {Event}                                 The created event
  */
 var createEvent = function(req, res) {
@@ -97,7 +98,8 @@ var createEvent = function(req, res) {
         'notes': req.body.notes,
         'organiserOther': GrasshopperUtil.toArray(req.body.organiserOther),
         'organiserUsers': GrasshopperUtil.toArray(req.body.organiserUsers),
-        'series': GrasshopperUtil.toArray(req.body.series)
+        'series': GrasshopperUtil.toArray(req.body.series),
+        'type': req.body.type
     };
     EventsAPI.createEvent(req.ctx, req.body.app, req.body.displayName, req.body.start, req.body.end, opts, function(err, event) {
         if (err) {
@@ -126,6 +128,7 @@ GrassHopper.globalAdminRouter.on('post', '/api/events', createEvent);
  * @FormParam   {group}                 [group]             Updated id of the group that can manage the event
  * @FormParam   {string}                [notes]             The updated notes for the event
  * @FormParam   {string}                [start]             The updated timestamp (ISO 8601) at which the event starts
+ * @FormParam   {string}                [type]              Updated event type
  * @Return      {Event}                                     The updated event
  */
 var updateEvent = function(req, res) {

--- a/node_modules/gh-events/tests/test-events.js
+++ b/node_modules/gh-events/tests/test-events.js
@@ -46,7 +46,8 @@ describe('Events', function() {
                     var opts = {
                         'description': 'Analysis of Up the movie',
                         'notes': 'Bring tissues',
-                        'location': 'Drama house, 2nd floor, room 304B'
+                        'location': 'Drama house, 2nd floor, room 304B',
+                        'type': 'lecture'
                     };
                     EventsTestUtil.assertCreateEvent(simon.client, 'Test event', start, end, opts, function(createdEvent) {
 
@@ -242,7 +243,12 @@ describe('Events', function() {
                                                                         EventsTestUtil.assertCreateEventFails(simon.client, 'Test event', end, start, opts, 400, function() {
                                                                             opts = {'series': [1, -1]};
                                                                             EventsTestUtil.assertCreateEventFails(simon.client, 'Test event', end, start, opts, 400, function() {
-                                                                                return callback();
+
+                                                                                // Too long event type
+                                                                                opts = {'type': TestsUtil.generateString(257)};
+                                                                                EventsTestUtil.assertCreateEventFails(simon.client, 'Test event', end, start, opts, 400, function() {
+                                                                                    return callback();
+                                                                                });
                                                                             });
                                                                         });
                                                                     });
@@ -462,7 +468,12 @@ describe('Events', function() {
                                                         // Unknown group
                                                         update = {'group': -1};
                                                         EventsTestUtil.assertUpdateEventFails(simon.client, event.id, update, 404, function() {
-                                                            return callback();
+
+                                                            // Too long event type
+                                                            update = {'type': TestsUtil.generateString(257)};
+                                                            EventsTestUtil.assertUpdateEventFails(simon.client, event.id, update, 400, function() {
+                                                                return callback();
+                                                            });
                                                         });
                                                     });
                                                 });

--- a/node_modules/gh-events/tests/util.js
+++ b/node_modules/gh-events/tests/util.js
@@ -52,6 +52,7 @@ var assertEvent = module.exports.assertEvent = function(event, expectedEvent) {
     assert.strictEqual(event.GroupId, expectedEvent.GroupId);
     assert.strictEqual(event.location, expectedEvent.location);
     assert.strictEqual(event.notes, expectedEvent.notes);
+    assert.strictEqual(event.type, expectedEvent.type);
     assert.deepEqual(event.organisers, expectedEvent.organisers);
 };
 
@@ -71,6 +72,7 @@ var assertEvent = module.exports.assertEvent = function(event, expectedEvent) {
  * @param  {String[]}           [opts.organiserOther]           The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
  * @param  {Number[]}           [opts.organiserUser]            The id(s) of the recognised user(s) that organise the event
  * @param  {Number[]}           [opts.serie]                    The id(s) of the serie(s) that the event belongs to
+ * @param  {String}             [opts.type]                     The type of the event
  * @param  {Function}           callback                        Standard callback function
  * @param  {Event}              callback.event                  The created event
  * @throws {AssertionError}                                     Error thrown when an assertion failed
@@ -96,6 +98,9 @@ var assertCreateEvent = module.exports.assertCreateEvent = function(client, disp
         }
         if (opts.location) {
             assert.strictEqual(createdEvent.location, opts.location);
+        }
+        if (opts.type) {
+            assert.strictEqual(createdEvent.type, opts.type);
         }
         if (opts.organiserOther) {
             assert.ok(createdEvent.organisers);
@@ -133,6 +138,7 @@ var assertCreateEvent = module.exports.assertCreateEvent = function(client, disp
  * @param  {String}             [opts.organiserOther]           The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
  * @param  {Number[]}           [opts.organiserUser]            The id(s) of the recognised user(s) that organise the event
  * @param  {Number[]}           [opts.serie]                    The id(s) of the serie(s) that the event belongs to
+ * @param  {String}             [opts.type]                     The type of the event
  * @param  {Number}             code                            The expected HTTP error code
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
@@ -358,7 +364,8 @@ var generateTestEvents = module.exports.generateTestEvents = function(client, to
     var displayName = TestsUtil.generateString(30);
     var opts = {
         'location': _.sample(LOCATIONS),
-        'organiserOther': [_.sample(ORGANISERS)]
+        'organiserOther': [_.sample(ORGANISERS)],
+        'type': TestsUtil.generateString(15)
     };
     assertCreateEvent(client, displayName, startFormatted, endFormatted, opts, function(event) {
         _events.push(event);

--- a/node_modules/gh-orgunit/lib/api.js
+++ b/node_modules/gh-orgunit/lib/api.js
@@ -797,7 +797,7 @@ var _getOrgUnitCalendar = function(ctx, id, start, end, callback) {
  */
 var _getCalendarInfo = function(ctx, orgUnit, format) {
     var link = util.format('https://%s/api/orgunit/%s/calendar.%s', ctx.app.host, orgUnit.id, format);
-    return new CalendarInfo(ctx.app.host, orgUnit.displayName, '', ctx.app.displayName, link, '', orgUnit.updatedAt);
+    return new CalendarInfo(ctx.app, orgUnit.displayName, '', ctx.app.displayName, link, '', orgUnit.updatedAt);
 };
 
 /* Utilities */

--- a/node_modules/gh-orgunit/lib/internal/dao.js
+++ b/node_modules/gh-orgunit/lib/internal/dao.js
@@ -368,7 +368,7 @@ var getOrgUnitCalendar = module.exports.getOrgUnitCalendar = function(orgUnit, s
     }
 
     // Minimise the amount of data we retrieve so Sequelize has less to deserialize
-    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'organiserOther', 'updatedAt'];
+    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'type', 'notes', 'organiserOther', 'updatedAt'];
     var userFields = ['id', 'displayName'];
 
     var options = {

--- a/node_modules/gh-orgunit/tests/util.js
+++ b/node_modules/gh-orgunit/tests/util.js
@@ -640,7 +640,7 @@ var assertGetOrgUnitCalendar = module.exports.assertGetOrgUnitCalendar = functio
         }
 
         // Assert only the required information is returned
-        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context'];
+        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context', 'type', 'notes'];
         var allowedContextKeys = ['id', 'ParentId', 'displayName', 'type'];
         _.each(calendar.results, function(event) {
             _.each(event, function(val, key) {

--- a/node_modules/gh-rest/lib/rest/event.js
+++ b/node_modules/gh-rest/lib/rest/event.js
@@ -49,6 +49,7 @@ module.exports = function(client) {
      * @param  {String}         [opts.organiserOther]           The name(s) of the unrecognised user(s) that organise the event. If no organisers are added, the current user will be added as the organiser
      * @param  {Number[]}       [opts.organiserUsers]           The id(s) of the recognised user(s) that organise the event
      * @param  {Number[]}       [opts.series]                   The id(s) of the serie(s) that the event belongs to
+     * @param  {String}         [opts.type]                     The type of the event
      * @param  {Function}       callback                        Standard callback function
      * @param  {Object}         callback.err                    An error that occurred, if any
      * @param  {Object}         callback.body                   The JSON response from the REST API
@@ -68,7 +69,8 @@ module.exports = function(client) {
             'organiserOther': opts.organiserOther,
             'organiserUsers': opts.organiserUsers,
             'series': opts.series,
-            'start': start
+            'start': start,
+            'type': opts.type
         };
         client._request('/api/events', 'POST', data, null, callback);
     };
@@ -85,6 +87,7 @@ module.exports = function(client) {
      * @param  {Number}         [update.group]                  Updated id of the group that can manage the event
      * @param  {String}         [update.notes]                  Updated notes for the event
      * @param  {String}         [update.start]                  Updated timestamp (ISO 8601) at which the event starts
+     * @param  {String}         [update.type]                   Updated type of the event
      * @param  {Function}       callback                        Standard callback function
      * @param  {Object}         callback.err                    An error that occurred, if any
      * @param  {Object}         callback.body                   The JSON response from the REST API

--- a/node_modules/gh-series/lib/api.js
+++ b/node_modules/gh-series/lib/api.js
@@ -624,7 +624,7 @@ var getSeriesCalendarAsRSS = module.exports.getSeriesCalendarAsRSS = function(ct
  */
 var _getCalendarInfo = function(ctx, serie, events) {
     var link = 'https://' + ctx.app.host + '/series/' + serie.id;
-    return new CalendarInfo(ctx.app.host, serie.displayName, '', ctx.app.displayName, link, '', serie.lastModified);
+    return new CalendarInfo(ctx.app, serie.displayName, '', ctx.app.displayName, link, '', serie.lastModified);
 };
 
 /**

--- a/node_modules/gh-users/lib/api.js
+++ b/node_modules/gh-users/lib/api.js
@@ -528,5 +528,5 @@ var resetUserCalendarToken = module.exports.resetUserCalendarToken = function(ct
  */
 var _getCalendarInfo = function(ctx, user, format) {
     var link = util.format('https://%s/api/user/%s/%s/calendar.%s', ctx.app.host, user.id, user.calendarToken, format);
-    return new CalendarInfo(ctx.app.host, user.displayName, '', ctx.app.displayName, link, '', user.updatedAt);
+    return new CalendarInfo(ctx.app, user.displayName, '', ctx.app.displayName, link, '', user.updatedAt);
 };

--- a/node_modules/gh-users/lib/internal/dao.js
+++ b/node_modules/gh-users/lib/internal/dao.js
@@ -377,7 +377,7 @@ var getUserCalendar = module.exports.getUserCalendar = function(user, includeCon
     // This query fetches such a massive amount of data, that the CPU usage
     // goes through the roof when Sequelize serialises it. To minimise this,
     // we retrieve only those columns we really need
-    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'organiserOther', 'updatedAt'];
+    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'type', 'notes', 'organiserOther', 'updatedAt'];
     var userFields = ['id', 'displayName'];
 
     var options = {

--- a/node_modules/gh-users/tests/test-calendar.js
+++ b/node_modules/gh-users/tests/test-calendar.js
@@ -411,6 +411,60 @@ describe('Users - calendars', function() {
                 });
             });
         });
+
+        /**
+         * Test that verifies the correct description is returned when getting a timetable calendar
+         */
+        it('verify the description when getting a timetable calendar', function(callback) {
+            TestsUtil.generateTestUsers(global.tests.apps.cam2013, 1, false, function(simon) {
+                UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                    // Set up an event with lots of metadata
+                    var calendarStart = moment().subtract(1, 'day').format();
+                    var calendarEnd = moment().add(30, 'day').format();
+                    SeriesTestUtil.generateSerieWithEvents(simon.client, 1, 1, calendarStart, calendarEnd, function(series) {
+                        var serie = series[0];
+                        var event = serie.events[0];
+                        var type = 'Lab';
+                        var notes = 'Whee, notes';
+                        EventsTestsUtil.assertUpdateEvent(global.tests.admins.cam2013.client, event.id, {'notes': notes, 'type': type}, function(updatedEvent) {
+
+                            // Subscribe on the series
+                            SeriesTestUtil.assertSubscribeSeries(simon.client, serie.id, simon.profile.id, null, function() {
+
+                                // Get the iCal feed
+                                UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [updatedEvent], function(calendar) {
+
+                                    // There should only be 1 event in the calendar
+                                    assert.strictEqual(calendar.subComponents.length, 1);
+                                    var expectedDescription = 'Lecturer: ' + event.organisers.join(', ') + '\n';
+                                    expectedDescription += 'Type: ' + type + '\n\n';
+                                    expectedDescription += notes;
+                                    assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
+
+                                    // Add another lecturer
+                                    var update = {'Mr Doo Little': true};
+                                    EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, event.id, update, function() {
+                                        EventsTestsUtil.assertGetEvent(simon.client, event.id, null, function(event) {
+
+                                            UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [event], function(calendar) {
+
+                                                // There should only be 1 event in the calendar
+                                                assert.strictEqual(calendar.subComponents.length, 1);
+                                                expectedDescription = 'Lecturers: ' + event.organisers.join(', ') + '\n';
+                                                expectedDescription += 'Type: ' + type + '\n\n';
+                                                expectedDescription += notes;
+                                                assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
+                                                return callback();
+                                            });
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
     });
 
     describe('RSS', function() {

--- a/node_modules/gh-users/tests/test-calendar.js
+++ b/node_modules/gh-users/tests/test-calendar.js
@@ -428,13 +428,11 @@ describe('Users - calendars', function() {
                         var notes = 'Whee, notes';
                         EventsTestsUtil.assertUpdateEvent(global.tests.admins.cam2013.client, event.id, {'notes': notes, 'type': type}, function(updatedEvent) {
 
-                            // Subscribe on the series
+                            // Subscribe to the series
                             SeriesTestUtil.assertSubscribeSeries(simon.client, serie.id, simon.profile.id, null, function() {
 
                                 // Get the iCal feed
                                 UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [updatedEvent], function(calendar) {
-
-                                    // There should only be 1 event in the calendar
                                     assert.strictEqual(calendar.subComponents.length, 1);
                                     var expectedDescription = 'Lecturer: ' + event.organisers.join(', ') + '\n';
                                     expectedDescription += 'Type: ' + type + '\n\n';
@@ -447,8 +445,6 @@ describe('Users - calendars', function() {
                                         EventsTestsUtil.assertGetEvent(simon.client, event.id, null, function(event) {
 
                                             UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [event], function(calendar) {
-
-                                                // There should only be 1 event in the calendar
                                                 assert.strictEqual(calendar.subComponents.length, 1);
                                                 expectedDescription = 'Lecturers: ' + event.organisers.join(', ') + '\n';
                                                 expectedDescription += 'Type: ' + type + '\n\n';

--- a/node_modules/gh-users/tests/test-calendar.js
+++ b/node_modules/gh-users/tests/test-calendar.js
@@ -413,6 +413,58 @@ describe('Users - calendars', function() {
         });
 
         /**
+         * Check that the correct description is returned in the iCal feeds
+         *
+         * @param  {Object}     user                    The user client and profile that can be used to retrieve the iCal feed
+         * @param  {Serie}      serie                   The serie to which the event needs to be added
+         * @param  {String[]}   organisers              A set of organisers for the event
+         * @param  {String}     [type]                  The event type
+         * @param  {String}     [notes]                 The event notes
+         * @param  {String}     expectedDescription     The description that should be returned by the iCal feed
+         * @param  {Function}   callback                Standard callback function
+         * @throws {AssertionError}                     Error thrown when an assertion failed
+         */
+        var checkICalEventDescription = function(user, serie, organisers, type, notes, expectedDescription, callback) {
+            // Create the event
+            var start = moment().subtract(1, 'day').format();
+            var end = moment(start).add(60, 'minute').format();
+            var opts = {
+                'type': type,
+                'notes': notes,
+                'series': [serie.id]
+            };
+            EventsTestsUtil.assertCreateEvent(global.tests.admins.cam2013.client, 'Test event', start, end, opts, function(event) {
+
+                // Ensure the correct organisers are present
+                var update = {};
+
+                // Always remove the auto-added one
+                update[global.tests.admins.cam2013.profile.id] = false;
+
+                // Add the specified organisers
+                _.each(organisers, function(organiser) {
+                    update[organiser] = true;
+                });
+                EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, event.id, update, function() {
+
+                    // Get the user's ical calendar
+                    UsersTestsUtil.assertGetUserCalendarICal(user.client, user.profile.id, user.profile.calendarToken, null, function(calendar) {
+                        // Get the event out of the calendar
+                        var icalEvent = _.find(calendar.subComponents, function(evt) {
+                            return (_.parseInt(evt.model.uid, 10) === event.id);
+                        });
+
+                        // Assert the description is what we expect it to be
+                        assert.strictEqual(icalEvent.model.description, expectedDescription);
+
+                        return callback();
+                    });
+                });
+
+            });
+        };
+
+        /**
          * Test that verifies the correct description is returned when getting a timetable calendar
          */
         it('verify the description when getting a timetable calendar', function(callback) {
@@ -423,64 +475,48 @@ describe('Users - calendars', function() {
                     var calendarEnd = moment().add(30, 'day').format();
                     SeriesTestUtil.generateSerieWithEvents(simon.client, 1, 1, calendarStart, calendarEnd, function(series) {
                         var serie = series[0];
-                        var event = serie.events[0];
-                        var type = 'Lab';
-                        var notes = 'Whee, notes';
-                        EventsTestsUtil.assertUpdateEvent(global.tests.admins.cam2013.client, event.id, {'notes': notes, 'type': type}, function(updatedEvent) {
 
-                            // Subscribe to the series
-                            SeriesTestUtil.assertSubscribeSeries(simon.client, serie.id, simon.profile.id, null, function() {
+                        // Let the user subscribe on the series
+                        SeriesTestUtil.assertSubscribeSeries(simon.client, serie.id, simon.profile.id, null, function() {
 
-                                // Get the iCal feed
-                                UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [updatedEvent], function(calendar) {
-                                    assert.strictEqual(calendar.subComponents.length, 1);
-                                    var expectedDescription = type + ' with ' + event.organisers.join(', ') + '\n\n' + notes;
-                                    assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
+                            // Check an event without any type, notes or organiser
+                            checkICalEventDescription(simon, serie, [], null, null, null, function() {
 
-                                    // Add another lecturer
-                                    var update = {'Mr Doo Little': true};
-                                    EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, event.id, update, function() {
-                                        EventsTestsUtil.assertGetEvent(simon.client, event.id, null, function(event) {
+                                // Check an event with only a type but no notes or organisers
+                                checkICalEventDescription(simon, serie, [], 'Lab', null, 'Lab', function() {
 
-                                            UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [event], function(calendar) {
-                                                assert.strictEqual(calendar.subComponents.length, 1);
-                                                expectedDescription = type + ' with ' + event.organisers.sort().join(', ') + '\n\n' + notes;
-                                                assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
+                                    // Check an event with only some notes but no type or organisers
+                                    checkICalEventDescription(simon, serie, [], null, 'bring paper', 'bring paper', function() {
 
-                                                // Remove the lecturers
-                                                _.each(event.organisers, function(organiser) {
-                                                    update[organiser] = false;
-                                                });
-                                                EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, event.id, update, function() {
+                                        // Check an event with both a type and notes but no organisers
+                                        checkICalEventDescription(simon, serie, [], 'Lab', 'bring paper', 'Lab\n\nbring paper', function() {
 
-                                                    // As there are no organisers, the description should just be a concatenation of type and notes
-                                                    UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [event], function(calendar) {
-                                                        assert.strictEqual(calendar.subComponents.length, 1);
-                                                        expectedDescription = type + '\n\n' + notes;
-                                                        assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
+                                            // Check an event with some organisers, but no type or notes
+                                            checkICalEventDescription(simon, serie, ['Jill'], null, null, 'with Jill', function() {
+                                                checkICalEventDescription(simon, serie, ['Jill', 'Jack'], null, null, 'with Jack, Jill', function() {
+                                                    checkICalEventDescription(simon, serie, ['Jack', 'Jill'], null, null, 'with Jack, Jill', function() {
 
-                                                        // Create an event without a type or notes and add it to the serie
-                                                        EventsTestsUtil.assertCreateEvent(global.tests.admins.cam2013.client, 'Test event', calendarStart, calendarEnd, null, function(newEvent) {
-                                                            SeriesTestUtil.assertAddSeriesEvents(global.tests.admins.cam2013.client, serie.id, [newEvent.id], function() {
-                                                                UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, null, function(calendar) {
-                                                                    var icalNewEvent = _.find(calendar.subComponents, function(evt) {
-                                                                        return (parseInt(evt.model.uid, 10) === newEvent.id);
-                                                                    });
-                                                                    var expectedDescription = 'with ' + newEvent.organisers[0].displayName;
-                                                                    assert.strictEqual(icalNewEvent.model.description, expectedDescription);
+                                                        // Check an event with some organisers and a type but no notes
+                                                        checkICalEventDescription(simon, serie, ['Jill'], 'Lab', null, 'Lab with Jill', function() {
+                                                            checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', null, 'Lab with Jack, Jill', function() {
+                                                                checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', null, 'Lab with Jack, Jill', function() {
 
-                                                                    // Remove the organiser
-                                                                    update[global.tests.admins.cam2013.profile.id] = false;
-                                                                    EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, newEvent.id, update, function() {
+                                                                    // Check an event with some organisers and some notes but no type
+                                                                    checkICalEventDescription(simon, serie, ['Jill'], null, 'bring paper', 'with Jill\n\nbring paper', function() {
+                                                                        checkICalEventDescription(simon, serie, ['Jill', 'Jack'], null, 'bring paper', 'with Jack, Jill\n\nbring paper', function() {
+                                                                            checkICalEventDescription(simon, serie, ['Jack', 'Jill'], null, 'bring paper', 'with Jack, Jill\n\nbring paper', function() {
 
-                                                                        // The description will be null when there are no event organisers, type or notes
-                                                                        UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, null, function(calendar) {
-                                                                            var icalNewEvent = _.find(calendar.subComponents, function(evt) {
-                                                                                return (parseInt(evt.model.uid, 10) === newEvent.id);
+                                                                                // Check an event with some organisers, a type and some notes
+                                                                                checkICalEventDescription(simon, serie, ['Jill'], 'Lab', 'bring paper', 'Lab with Jill\n\nbring paper', function() {
+                                                                                    checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
+                                                                                        checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
+
+
+                                                                                            return callback();
+                                                                                        });
+                                                                                    });
+                                                                                });
                                                                             });
-                                                                            assert.strictEqual(icalNewEvent.model.description, null);
-
-                                                                            return callback();
                                                                         });
                                                                     });
                                                                 });

--- a/node_modules/gh-users/tests/test-calendar.js
+++ b/node_modules/gh-users/tests/test-calendar.js
@@ -417,7 +417,7 @@ describe('Users - calendars', function() {
          *
          * @param  {Object}     user                    The user client and profile that can be used to retrieve the iCal feed
          * @param  {Serie}      serie                   The serie to which the event needs to be added
-         * @param  {String[]}   organisers              A set of organisers for the event
+         * @param  {String[]}   [organisers]            A set of organisers for the event
          * @param  {String}     [type]                  The event type
          * @param  {String}     [notes]                 The event notes
          * @param  {String}     expectedDescription     The description that should be returned by the iCal feed
@@ -510,7 +510,6 @@ describe('Users - calendars', function() {
                                                                                 checkICalEventDescription(simon, serie, ['Jill'], 'Lab', 'bring paper', 'Lab with Jill\n\nbring paper', function() {
                                                                                     checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
                                                                                         checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
-
 
                                                                                             return callback();
                                                                                         });

--- a/node_modules/gh-users/tests/test-calendar.js
+++ b/node_modules/gh-users/tests/test-calendar.js
@@ -434,9 +434,7 @@ describe('Users - calendars', function() {
                                 // Get the iCal feed
                                 UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [updatedEvent], function(calendar) {
                                     assert.strictEqual(calendar.subComponents.length, 1);
-                                    var expectedDescription = 'Lecturer: ' + event.organisers.join(', ') + '\n';
-                                    expectedDescription += 'Type: ' + type + '\n\n';
-                                    expectedDescription += notes;
+                                    var expectedDescription = type + ' with ' + event.organisers.join(', ') + '\n\n' + notes;
                                     assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
 
                                     // Add another lecturer
@@ -446,11 +444,50 @@ describe('Users - calendars', function() {
 
                                             UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [event], function(calendar) {
                                                 assert.strictEqual(calendar.subComponents.length, 1);
-                                                expectedDescription = 'Lecturers: ' + event.organisers.join(', ') + '\n';
-                                                expectedDescription += 'Type: ' + type + '\n\n';
-                                                expectedDescription += notes;
+                                                expectedDescription = type + ' with ' + event.organisers.sort().join(', ') + '\n\n' + notes;
                                                 assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
-                                                return callback();
+
+                                                // Remove the lecturers
+                                                _.each(event.organisers, function(organiser) {
+                                                    update[organiser] = false;
+                                                });
+                                                EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, event.id, update, function() {
+
+                                                    // As there are no organisers, the description should just be a concatenation of type and notes
+                                                    UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, [event], function(calendar) {
+                                                        assert.strictEqual(calendar.subComponents.length, 1);
+                                                        expectedDescription = type + '\n\n' + notes;
+                                                        assert.strictEqual(calendar.subComponents[0].model.description, expectedDescription);
+
+                                                        // Create an event without a type or notes and add it to the serie
+                                                        EventsTestsUtil.assertCreateEvent(global.tests.admins.cam2013.client, 'Test event', calendarStart, calendarEnd, null, function(newEvent) {
+                                                            SeriesTestUtil.assertAddSeriesEvents(global.tests.admins.cam2013.client, serie.id, [newEvent.id], function() {
+                                                                UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, null, function(calendar) {
+                                                                    var icalNewEvent = _.find(calendar.subComponents, function(evt) {
+                                                                        return (parseInt(evt.model.uid, 10) === newEvent.id);
+                                                                    });
+                                                                    var expectedDescription = 'with ' + newEvent.organisers[0].displayName;
+                                                                    assert.strictEqual(icalNewEvent.model.description, expectedDescription);
+
+                                                                    // Remove the organiser
+                                                                    update[global.tests.admins.cam2013.profile.id] = false;
+                                                                    EventsTestsUtil.assertUpdateEventOrganisers(global.tests.admins.cam2013.client, newEvent.id, update, function() {
+
+                                                                        // The description will be null when there are no event organisers, type or notes
+                                                                        UsersTestsUtil.assertGetUserCalendarICal(simon.client, simon.profile.id, me.calendarToken, null, function(calendar) {
+                                                                            var icalNewEvent = _.find(calendar.subComponents, function(evt) {
+                                                                                return (parseInt(evt.model.uid, 10) === newEvent.id);
+                                                                            });
+                                                                            assert.strictEqual(icalNewEvent.model.description, null);
+
+                                                                            return callback();
+                                                                        });
+                                                                    });
+                                                                });
+                                                            });
+                                                        });
+                                                    });
+                                                });
                                             });
                                         });
                                     });

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -363,7 +363,7 @@ var assertGetUserCalendar = module.exports.assertGetUserCalendar = function(clie
         }
 
         // Assert only the required information is returned
-        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context'];
+        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context', 'type', 'notes'];
         var allowedContextKeys = ['id', 'ParentId', 'displayName', 'type'];
         _.each(calendar.results, function(event) {
             _.each(event, function(val, key) {


### PR DESCRIPTION
Not sure if this is a regression, but a quick test today showed that exported feeds don't contain all the event information. Currently the legacy TT adds the organiser to the DESCRIPTION field in the feed. 

I would suggest we concatenate the following info as DESCRIPTION for each event:
```
Lecturer: {{Organiser name}}
Type: {{Event type}}

{{Notes field content}}
```

Any thoughts / ideas?

EDIT: Assuming we are using event "notes" properly, and event "type" properly
