### PR TITLE
Rename Google Analytics configuration variables

### DIFF
--- a/node_modules/gh-config/lib/internal/dao.js
+++ b/node_modules/gh-config/lib/internal/dao.js
@@ -24,7 +24,7 @@ var log = require('gh-core/lib/logger').logger('gh-config');
 // The editable fields
 var fields = ['allowLocalAccountCreation', 'enableLocalAuth', 'enableShibbolethAuth', 'shibIdpEntityId',
               'shibExternalIdAttributes', 'shibMapDisplayname', 'shibMapEmail', 'allowUserEventCreation',
-              'allowUserSerieCreation', 'enableGoogleAnalytics', 'googleAnalyticsTrackingId', 'academicYear'];
+              'allowUserSerieCreation', 'enableAnalytics', 'analyticsTrackingId', 'academicYear'];
 module.exports.EDITABLE_FIELDS = fields;
 
 /**

--- a/node_modules/gh-config/lib/restmodel.js
+++ b/node_modules/gh-config/lib/restmodel.js
@@ -24,10 +24,10 @@
  * @Property  {Boolean}                 allowLocalAccountCreation           Whether or not local accounts can be created
  * @Property  {Boolean}                 allowUserEventCreation              Whether or not regular users can create events
  * @Property  {Boolean}                 allowUserSerieCreation              Whether or not regular users can create series
- * @Property  {Boolean}                 enableGoogleAnalytics               Whether or not Google Analytics should be enabled for this application
+ * @Property  {Boolean}                 enableAnalytics                     Whether or not Segment.io analytics should be enabled for this application
  * @Property  {Boolean}                 enableLocalAuth                     Whether or not local authentication is enabled
  * @Property  {Boolean}                 enableShibbolethAuth                Whether or not shibboleth authenticated is enabled
- * @Property  {String}                  googleAnalyticsTrackingId           The Google Analytics tracking identifier
+ * @Property  {String}                  analyticsTrackingId                 The Segment.io analytics tracking identifier
  * @Property  {String}                  shibIdpEntityId                     The entity ID of the Shibboleth Identity Provider that should be used
  * @Property  {String}                  shibExternalIdAttributes            The attribute that uniquely identifies the user. This should be a prioritised space seperated list
  * @Property  {String}                  shibMapDisplayname                  The attibute(s) that should be used to construct the displayname. This should be a prioritised space seperated list

--- a/node_modules/gh-config/tests/util.js
+++ b/node_modules/gh-config/tests/util.js
@@ -42,8 +42,8 @@ var assertGetConfig = module.exports.assertGetConfig = function(client, appId, e
         assert.ok(_.has(config, 'allowUserSerieCreation'));
         assert.ok(_.has(config, 'enableLocalAuth'));
         assert.ok(_.has(config, 'enableShibbolethAuth'));
-        assert.ok(_.has(config, 'enableGoogleAnalytics'));
-        assert.ok(_.has(config, 'googleAnalyticsTrackingId'));
+        assert.ok(_.has(config, 'enableAnalytics'));
+        assert.ok(_.has(config, 'analyticsTrackingId'));
 
         if (expectSuppressed) {
             assert.ok(_.isUndefined(config.shibIdpEntityId));

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -626,8 +626,8 @@ var _setUpModel = function(sequelize) {
      * @property {String}       shibMapEmail                        The attibute(s) that should be used to construct the email. This should be a prioritised space seperated list
      * @property {Boolean}      allowUserEventCreation              Whether or not regular users can create events
      * @property {Boolean}      allowUserSerieCreation              Whether or not regular users can create series
-     * @property {Boolean}      enableGoogleAnalytics               Whether or not Google Analytics should be enabled for this application
-     * @property {Boolean}      googleAnalyticsTrackingId           The Google Analytics tracking identifier
+     * @property {Boolean}      enableAnalytics                     Whether or not Segment.io analytics should be enabled for this application
+     * @property {Boolean}      analyticsTrackingId                 The Segment.io analytics tracking identifier
      * @property {String}       academicYear                        The academic year for an application
      * @property {App}          app                                 The application with which the configuration is associated
      */
@@ -673,12 +673,12 @@ var _setUpModel = function(sequelize) {
             'defaultValue': true,
             'allowNull': false
         },
-        'enableGoogleAnalytics': {
+        'enableAnalytics': {
             'type': Sequelize.BOOLEAN,
             'defaultValue': false,
             'allowNull': false
         },
-        'googleAnalyticsTrackingId': {
+        'analyticsTrackingId': {
             'type': Sequelize.TEXT,
             'defaultValue': ''
         },


### PR DESCRIPTION
The UI will be using segment.io to pipe data through to various analytics platforms. I've renamed the GA configuration variables to more generic names.