### PR TITLE
Test failure in Series iCal tests

### DIFF
--- a/node_modules/gh-series/tests/test-calendar.js
+++ b/node_modules/gh-series/tests/test-calendar.js
@@ -52,7 +52,14 @@ describe('Series - calendar', function() {
                             // Verify date filtering by generating a window that contains the first event
                             rangeStart = serie.events[0].start;
                             rangeEnd = serie.events[0].end;
-                            SeriesTestUtil.assertGetSeriesCalendar(simon.client, serie.id, rangeStart, rangeEnd, [serie.events[0]], function() {
+
+                            // Because the events are generated randomly, it's possible that there is a second (or third)
+                            // event that's in the range of the first event. To avoid intermittent failures we select all
+                            // the events that happen in this range
+                            var expectedEvents = _.filter(serie.events, function(event) {
+                                return (event.start >= rangeStart && event.end <= rangeEnd);
+                            });
+                            SeriesTestUtil.assertGetSeriesCalendar(simon.client, serie.id, rangeStart, rangeEnd, expectedEvents, function() {
                                 return callback();
                             });
                         });
@@ -139,7 +146,14 @@ describe('Series - calendar', function() {
                             // Verify date filtering by generating a window that contains the first event
                             rangeStart = serie.events[0].start;
                             rangeEnd = serie.events[0].end;
-                            SeriesTestUtil.assertGetSeriesCalendarRss(simon.client, serie.id, rangeStart, rangeEnd, [serie.events[0]], function() {
+
+                            // Because the events are generated randomly, it's possible that there is a second (or third)
+                            // event that's in the range of the first event. To avoid intermittent failures we select all
+                            // the events that happen in this range
+                            var expectedEvents = _.filter(serie.events, function(event) {
+                                return (event.start >= rangeStart && event.end <= rangeEnd);
+                            });
+                            SeriesTestUtil.assertGetSeriesCalendarRss(simon.client, serie.id, rangeStart, rangeEnd, expectedEvents, function() {
                                 return callback();
                             });
                         });
@@ -218,7 +232,14 @@ describe('Series - calendar', function() {
                             // Verify date filtering by generating a window that contains the first event
                             rangeStart = serie.events[0].start;
                             rangeEnd = serie.events[0].end;
-                            SeriesTestUtil.assertGetSeriesCalendarIcal(simon.client, serie.id, rangeStart, rangeEnd, [serie.events[0]], function() {
+
+                            // Because the events are generated randomly, it's possible that there is a second (or third)
+                            // event that's in the range of the first event. To avoid intermittent failures we select all
+                            // the events that happen in this range
+                            var expectedEvents = _.filter(serie.events, function(event) {
+                                return (event.start >= rangeStart && event.end <= rangeEnd);
+                            });
+                            SeriesTestUtil.assertGetSeriesCalendarIcal(simon.client, serie.id, rangeStart, rangeEnd, expectedEvents, function() {
                                 return callback();
                             });
                         });


### PR DESCRIPTION
```
1 failing
  1) Series - calendar iCal verify a series calendar can be retrieved as iCal:
     Uncaught AssertionError: 2 === 1
      at /home/travis/build/fronteerio/grasshopper/node_modules/gh-series/tests/util.js:523:24
      at /home/travis/build/fronteerio/grasshopper/node_modules/gh-tests/lib/util.js:9:19027
      at LineStream.<anonymous> (/home/travis/build/fronteerio/grasshopper/node_modules/cozy-ical/lib/index.js:935:16)
      at LineStream.emit (events.js:117:20)
      at _stream_readable.js:938:16
      at process._tickDomainCallback (node.js:463:13)
```