### PR TITLE
Leave poor grasshopper.com alone

### DIFF
--- a/config.js
+++ b/config.js
@@ -86,10 +86,10 @@ config.cookie = {
  * @property  {String}      shibbolethSPHost        The hostname on which the Shibboleth Service Provider software will be made available
  */
 config.servers = {
-    'adminHostname': 'admin.grasshopper.com',
+    'adminHostname': 'admin.grasshopper.local',
     'adminPort': 2000,
     'appsPort': 2001,
-    'shibbolethSPHost': 'shib-sp.grasshopper.com'
+    'shibbolethSPHost': 'shib-sp.grasshopper.local'
 };
 
 /*!

--- a/etc/apache/README.md
+++ b/etc/apache/README.md
@@ -8,33 +8,33 @@ TODO
 
 As Grasshopper is a multi-tenant application, Shibboleth authentication is not entirely standard.
 
-Shibboleth authentication is exposed on a single domain name. For example, `shib-sp.grasshopper.local`.
-Assume that a user wants to log in on an application running on `timetable.grasshopper.local`. The following steps
+Shibboleth authentication is exposed on a single domain name. For example, `shib-sp.grasshopper.fronteer.io`.
+Assume that a user wants to log in on an application running on `timetable.grasshopper.fronteer.io`. The following steps
 are involved in this:
 
-1. On `timetable.grasshopper`, the user clicks the "Sign in with Shib" button. This will submit a form that
-takes them to `https://timetable.grasshopper.local/api/auth/shibboleth`.
+1. On `timetable.grasshopper.fronteer.io`, the user clicks the "Sign in with Shib" button. This will submit a form that
+takes them to `https://timetable.grasshopper.fronteer.io/api/auth/shibboleth`.
 This endpoint will:
  - check if Shibboleth authentication is enabled for the application
  - remember the `redirectUrl` (a URL where the user needs to be redirected to when they come back)
  - redirect the user to the "Shibboleth application"
 
-2. The user is now being redirected to `https://shib-sp.grasshopper.local/api/auth/shibboleth/sp?<signature>&<app>`
+2. The user is now being redirected to `https://shib-sp.grasshopper.fronteer.io/api/auth/shibboleth/sp?<signature>&<app>`
 This endpoint will:
  - ensure the user came from a valid Grasshopper tenant (so we don't become an open proxy)
  - Validate some settings
  - Store which application the user came from
- - Redirect the user to `https://shib-sp.grasshopper.local/Shibboleth.SSO/Login?<service provider>`
+ - Redirect the user to `https://shib-sp.grasshopper.fronteer.io/Shibboleth.SSO/Login?<service provider>`
 
 
 3. Now mod_shib will take over and send the user over to their institution's IdP
 
-4. The user authenticates at their IdP and arrives back at `https://shib-sp.grasshopper.local/api/auth/shibboleth/sp/callback`
+4. The user authenticates at their IdP and arrives back at `https://shib-sp.grasshopper.fronteer.io/api/auth/shibboleth/sp/callback`
 This endpoint will:
  - ensure the mod_shib auth was succesful
  - redirect the user back to the application he came from
 
-5. The user is back at his application at `https://timetable.grasshopper.local/api/auth/shibboleth/callback`
+5. The user is back at his application at `https://timetable.grasshopper.fronteer.io/api/auth/shibboleth/callback`
 This endpoint will:
  - ensure the request is valid
  - initiate a user session

--- a/etc/apache/README.md
+++ b/etc/apache/README.md
@@ -8,33 +8,33 @@ TODO
 
 As Grasshopper is a multi-tenant application, Shibboleth authentication is not entirely standard.
 
-Shibboleth authentication is exposed on a single domain name. For example, `shib-sp.grasshopper.com`.
-Assume that a user wants to log in on an application running on `timetable.grasshopper.com`. The following steps
+Shibboleth authentication is exposed on a single domain name. For example, `shib-sp.grasshopper.local`.
+Assume that a user wants to log in on an application running on `timetable.grasshopper.local`. The following steps
 are involved in this:
 
 1. On `timetable.grasshopper`, the user clicks the "Sign in with Shib" button. This will submit a form that
-takes them to `https://timetable.grasshopper.com/api/auth/shibboleth`.
+takes them to `https://timetable.grasshopper.local/api/auth/shibboleth`.
 This endpoint will:
  - check if Shibboleth authentication is enabled for the application
  - remember the `redirectUrl` (a URL where the user needs to be redirected to when they come back)
  - redirect the user to the "Shibboleth application"
 
-2. The user is now being redirected to `https://shib-sp.grasshopper.com/api/auth/shibboleth/sp?<signature>&<app>`
+2. The user is now being redirected to `https://shib-sp.grasshopper.local/api/auth/shibboleth/sp?<signature>&<app>`
 This endpoint will:
  - ensure the user came from a valid Grasshopper tenant (so we don't become an open proxy)
  - Validate some settings
  - Store which application the user came from
- - Redirect the user to `https://shib-sp.grasshopper.com/Shibboleth.SSO/Login?<service provider>`
+ - Redirect the user to `https://shib-sp.grasshopper.local/Shibboleth.SSO/Login?<service provider>`
 
 
 3. Now mod_shib will take over and send the user over to their institution's IdP
 
-4. The user authenticates at their IdP and arrives back at `https://shib-sp.grasshopper.com/api/auth/shibboleth/sp/callback`
+4. The user authenticates at their IdP and arrives back at `https://shib-sp.grasshopper.local/api/auth/shibboleth/sp/callback`
 This endpoint will:
  - ensure the mod_shib auth was succesful
  - redirect the user back to the application he came from
 
-5. The user is back at his application at `https://timetable.grasshopper.com/api/auth/shibboleth/callback`
+5. The user is back at his application at `https://timetable.grasshopper.local/api/auth/shibboleth/callback`
 This endpoint will:
  - ensure the request is valid
  - initiate a user session

--- a/etc/apache/shib.conf
+++ b/etc/apache/shib.conf
@@ -1,6 +1,6 @@
-<VirtualHost shib-sp.grasshopper.fronteer.io:443>
-    ServerAdmin admin@grasshopper.com
-    ServerName shib-sp.grasshopper.fronteer.io
+<VirtualHost shib-sp.grasshopper.local:443>
+    ServerAdmin admin@grasshopper.local
+    ServerName shib-sp.grasshopper.local
     DocumentRoot /opt/grasshopper-ui/apps/timetable/ui
     ErrorLog /var/log/apache2/shib_error.log
     CustomLog /var/log/apache2/shib_custom.log common

--- a/node_modules/gh-admins/lib/api.js
+++ b/node_modules/gh-admins/lib/api.js
@@ -16,7 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-var DB = require('gh-core/lib/db');
 var GrasshopperUtil = require('gh-core/lib/util');
 var log = require('gh-core/lib/logger').logger('gh-users');
 var Validator = require('gh-core/lib/validator').Validator;
@@ -34,8 +33,6 @@ var AdminsDAO = require('./internal/dao');
  * @param  {GlobalAdminList}    callback.globalAdmins       All available global administrators
  */
 var getGlobalAdmins = module.exports.getGlobalAdmins = function(ctx, limit, offset, callback) {
-    callback = callback || function() {};
-
     // Ensure that the paging values are valid
     limit = GrasshopperUtil.getNumberParam(limit, 10, 1, 25);
     offset = GrasshopperUtil.getNumberParam(offset, 0, 0);
@@ -60,8 +57,6 @@ var getGlobalAdmins = module.exports.getGlobalAdmins = function(ctx, limit, offs
  * @param  {GlobalAdmin}        callback.globalAdmin        The requested global administrator
  */
 var getGlobalAdmin = module.exports.getGlobalAdmin = function(ctx, id, callback) {
-    callback = callback || function() {};
-
     // Ensure that the global administrator id is a valid number
     id = GrasshopperUtil.getNumberParam(id);
 
@@ -86,8 +81,6 @@ var getGlobalAdmin = module.exports.getGlobalAdmin = function(ctx, id, callback)
  * @param  {GlobalAdmin}        callback.globalAdmin        The requested global administrator
  */
 var getGlobalAdminByUsername = module.exports.getGlobalAdminByUsername = function(ctx, username, callback) {
-    callback = callback || function() {};
-
     // Validation
     var validator = new Validator();
     validator.check(null, {'code': 401, 'msg': 'Only global administrators can get a global administrator by username'}).isGlobalAdmin(ctx);
@@ -111,18 +104,21 @@ var getGlobalAdminByUsername = module.exports.getGlobalAdminByUsername = functio
  * @param  {GlobalAdmin}        callback.globalAdmin        The created global administrator
  */
 var createGlobalAdmin = module.exports.createGlobalAdmin = function(ctx, username, password, displayName, callback) {
-    // TODO: Check that user is a global adminstrator
-    // TODO: username validation
-    // TODO: displayName validation
-    // TODO: password validation
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'Only global administrators can get a global administrator by username'}).isGlobalAdmin(ctx);
+    validator.check(username, {'code': 400, 'msg': 'A username must be provided'}).notEmpty();
+    validator.check(password, {'code': 400, 'msg': 'A password must be provided'}).notEmpty();
+    validator.check(displayName, {'code': 400, 'msg': 'A display name must be provided'}).notEmpty();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
 
-    // Ensure that a global administrator with the provided username doesn't alrady exist
+    // Ensure that a global administrator with the provided username doesn't already exist
     getGlobalAdminByUsername(ctx, username, function(err, globalAdmin) {
-        if (globalAdmin) {
-            log().error({'err': err, 'username': username}, 'Failed to create a new global administrator');
-            return callback({'code': 400, 'msg': 'A global administrator with the provided username already exists'});
-        } else if (err && err.code !== 404) {
+        if (err && err.code !== 404) {
             return callback(err);
+        } else if (globalAdmin) {
+            return callback({'code': 400, 'msg': 'A global administrator with the provided username already exists'});
         }
 
         return AdminsDAO.createGlobalAdmin(username, password, displayName, callback);
@@ -140,8 +136,17 @@ var createGlobalAdmin = module.exports.createGlobalAdmin = function(ctx, usernam
  * @param  {GlobalAdmin}        callback.globalAdmin        The updated global administrator
  */
 var updateGlobalAdmin = module.exports.updateGlobalAdmin = function(ctx, id, displayName, callback) {
-    // TODO: Check that user is a global adminstrator
-    // TODO: displayName validation
+    // Ensure the global administrator id is a valid number
+    id = GrasshopperUtil.getNumberParam(id);
+
+    // Validation
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'Only global administrators can update a global administrator'}).isGlobalAdmin(ctx);
+    validator.check(id, {'code': 400, 'msg': 'A valid global administrator id must be provided'}).isInt();
+    validator.check(displayName, {'code': 400, 'msg': 'A display name must be provided for update'}).notEmpty();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
 
     // Verify that the provided global administrator exists
     getGlobalAdmin(ctx, id, function(err, globalAdmin) {
@@ -162,8 +167,11 @@ var updateGlobalAdmin = module.exports.updateGlobalAdmin = function(ctx, id, dis
  * @param  {Object}     callback.err    An error that occurred, if any
  */
 var deleteGlobalAdmin = module.exports.deleteGlobalAdmin = function(ctx, id, callback) {
-    // TODO: Check that the user is a global administrator
+    // Ensure the global administrator id is a valid number
+    id = GrasshopperUtil.getNumberParam(id);
+
     var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'Only global administrators can update a global administrator'}).isGlobalAdmin(ctx);
     validator.check(id, {'code': 400, 'msg': 'A valid global administrator id must be provided'}).isInt();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
@@ -183,6 +191,7 @@ var deleteGlobalAdmin = module.exports.deleteGlobalAdmin = function(ctx, id, cal
                 return callback(err);
             }
 
+            // Finally delete the global admin
             return AdminsDAO.deleteGlobalAdmin(globalAdmin, callback);
         });
     });

--- a/node_modules/gh-admins/tests/test-admins.js
+++ b/node_modules/gh-admins/tests/test-admins.js
@@ -24,7 +24,175 @@ var TestsUtil = require('gh-tests/lib/util');
 
 var AdminsTestsUtil = require('./util');
 
+var anonymousGlobalAdminClient = null;
+var globalAdminClient = null;
+
+beforeEach(function(callback) {
+    // Get the anonymous and authenticated global admin clients
+    TestsUtil.getAnonymousGlobalAdminRestClient(function(_anonymousGlobalAdminClient) {
+        anonymousGlobalAdminClient = _anonymousGlobalAdminClient;
+        TestsUtil.getGlobalAdminRestClient(function(_globalAdminClient) {
+            globalAdminClient = _globalAdminClient;
+            return callback();
+        });
+    });
+});
+
 describe('Admins', function() {
+
+    describe('Get Global Admins', function() {
+
+        it('verify a list of global admins can be fetched', function(callback) {
+            // Ensure we have more than 1 global admin to test with
+            AdminsTestsUtil.assertGetMe(globalAdminClient, function(globalAdmin) {
+                var username = TestsUtil.generateTestUserId();
+                AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
+                    // Get all global admins in pages, ensuring each page contains just 1 global
+                    // admin, including the initial one and the created one
+                    AdminsTestsUtil.assertGetAllGlobalAdmins(globalAdminClient, {'batchSize': 1}, function(allGlobalAdmins, responses) {
+                        assert.ok(responses.length > 1);
+
+                        // When fetching with size 1, we'll always have one extra request for the
+                        // empty response. So subtract `responses.length` by 1 for the assertion
+                        assert.strictEqual(allGlobalAdmins.length, responses.length - 1);
+                        AdminsTestsUtil.assertGlobalAdmin(_.findWhere(allGlobalAdmins, {'id': globalAdmin.id}), {'exists': true});
+                        AdminsTestsUtil.assertGlobalAdmin(_.findWhere(allGlobalAdmins, {'id': createdGlobalAdmin.id}), {'exists': true});
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        it('verify authorization of getting a list of global admins', function(callback) {
+            // Ensure anonymous user cannot get global admin list
+            return AdminsTestsUtil.assertGetGlobalAdminsFails(anonymousGlobalAdminClient, null, 401, callback);
+        });
+    });
+
+    describe('Me', function() {
+
+        it('verify the "me" feed will be anonymous for anonymous users', function(callback) {
+            TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
+                AdminsTestsUtil.assertGetMe(anonymousGlobalAdminClient, function(me) {
+                    AdminsTestsUtil.assertMe(me, {'authenticated': false});
+                    return callback();
+                });
+            });
+        });
+
+        it('verify the "me" feed will specify the expected admins profile information', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
+
+                // Ensure the Me feed indicates the admin is logged in
+                AdminsTestsUtil.assertGetMe(createdGlobalAdminClient, function(me) {
+                    AdminsTestsUtil.assertMe(me, {'authenticated': createdGlobalAdmin});
+                    return callback();
+                });
+            });
+        });
+    });
+
+    describe('Create', function() {
+
+        it('verify validation of creating a global admin', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+
+            // Ensure parameter validation
+            AdminsTestsUtil.assertCreateGlobalAdminFails(globalAdminClient, '', username, username, 400, function() {
+                AdminsTestsUtil.assertCreateGlobalAdminFails(globalAdminClient, username, '', username, 400, function() {
+                    AdminsTestsUtil.assertCreateGlobalAdminFails(globalAdminClient, username, username, '', 400, function() {
+
+                        // Sanity check creation succeeds
+                        AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
+
+                            // Ensure we cannot create an admin with the same username
+                            return AdminsTestsUtil.assertCreateGlobalAdminFails(globalAdminClient, username, username, username, 400, callback);
+                        });
+                    });
+                });
+            });
+        });
+
+        it('verify authorization of creating a global admin', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+            TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
+
+                // Ensure anonymous can't create a global admin
+                AdminsTestsUtil.assertCreateGlobalAdminFails(anonymousGlobalAdminClient, username, username, username, 401, function(createdGlobalAdmin) {
+
+                    // Sanity check global admin can create one
+                    AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
+                        return callback();
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Update', function() {
+
+        it('verify updating a global admin', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
+
+                // Ensure a global admin can update their own properties, as well as another
+                AdminsTestsUtil.assertUpdateGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, 'display name', function() {
+                    AdminsTestsUtil.assertUpdateGlobalAdmin(createdGlobalAdminClient, createdGlobalAdmin.id, username, function() {
+                        return callback();
+                    });
+                });
+            });
+        });
+
+        it('verify validation of updating a global admin', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
+
+                // Ensure valid global admin id
+                AdminsTestsUtil.assertUpdateGlobalAdminFails(globalAdminClient, '', 'display name', 400, function() {
+                    AdminsTestsUtil.assertUpdateGlobalAdminFails(globalAdminClient, 'not an id', 'display name', 400, function() {
+
+                        // Ensure valid display name
+                        AdminsTestsUtil.assertUpdateGlobalAdminFails(globalAdminClient, createdGlobalAdmin.id, '', 400, function() {
+
+                            // Ensure the display name hasn't changed
+                            AdminsTestsUtil.assertGetMe(createdGlobalAdminClient, function(me) {
+                                AdminsTestsUtil.assertMe(me, {'authenticated': createdGlobalAdmin});
+
+                                // Sanity check we can udpate the display name
+                                AdminsTestsUtil.assertUpdateGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, 'display name', function() {
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        it('verify authorization of updating a global admin', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
+
+                // Ensure anonymous user can't update a global admin
+                TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
+                    AdminsTestsUtil.assertUpdateGlobalAdminFails(anonymousGlobalAdminClient, createdGlobalAdmin.id, 'display name', 401, function() {
+
+                        // Ensure the created global admin hasn't changed
+                        AdminsTestsUtil.assertGetMe(createdGlobalAdminClient, function(me) {
+                            AdminsTestsUtil.assertMe(me, {'authenticated': createdGlobalAdmin});
+
+                            // Sanity check we can update the created global admin
+                            AdminsTestsUtil.assertUpdateGlobalAdmin(createdGlobalAdminClient, createdGlobalAdmin.id, 'display name', function() {
+                                return callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
 
     describe('Delete', function() {
 
@@ -32,16 +200,12 @@ describe('Admins', function() {
          * Test that verifies a global admin can delete another global admin
          */
         it('verify a global admin can delete another global admin', function(callback) {
-            // Create the global admin rest client to test with
-            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+            // Create a global admin user that we can delete
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
 
-                // Create a global admin user that we can delete
-                var username = TestsUtil.generateTestUserId();
-                AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
-
-                    // Delete the global admin, ensuring they no longer exist
-                    return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
-                });
+                // Delete the global admin, ensuring they no longer exist
+                return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
             });
         });
 
@@ -49,13 +213,10 @@ describe('Admins', function() {
          * Test that verifies a global admin can delete their own user account
          */
         it('verify a global admin can delete their own user account', function(callback) {
-            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
-                var username = TestsUtil.generateTestUserId();
-                AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
-
-                    // Delete the global admin, ensuring they no longer exist
-                    return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
-                });
+            // Create a global admin to try and delete
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
+                return AdminsTestsUtil.assertDeleteGlobalAdmin(createdGlobalAdminClient, createdGlobalAdmin.id, callback);
             });
         });
 
@@ -63,25 +224,22 @@ describe('Admins', function() {
          * Test that verifies the last global admin cannot be deleted
          */
         it('verify we cannot be left with no global admins', function(callback) {
-            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+            // Get the main global admin to try and delete
+            AdminsTestsUtil.assertGetMe(globalAdminClient, function(globalAdminMe) {
 
-                // Get the main global admin to try and delete them
-                AdminsTestsUtil.assertGetMe(globalAdminClient, function(globalAdminMe) {
+                // Compile a list of all global admin ids except for the main one
+                AdminsTestsUtil.assertGetAllGlobalAdmins(globalAdminClient, null, function(globalAdmins) {
 
-                    // Compile a list of all global admin ids except for the main one
-                    AdminsTestsUtil.assertGetAllGlobalAdmins(globalAdminClient, null, function(globalAdmins) {
+                    // Delete all global admins except for the main one
+                    var globalAdminIds = _.chain(globalAdmins)
+                        .pluck('id')
+                        .without(globalAdminMe.id)
+                        .value();
+                    AdminsTestsUtil.assertDeleteGlobalAdmins(globalAdminClient, globalAdminIds, function() {
 
-                        // Delete all global admins except for the main one
-                        var globalAdminIds = _.chain(globalAdmins)
-                            .pluck('id')
-                            .without(globalAdminMe.id)
-                            .value();
-                        AdminsTestsUtil.assertDeleteGlobalAdmins(globalAdminClient, globalAdminIds, function() {
-
-                            // Ensure that the global admin now trying to delete themself (the only
-                            // remaining global admin) fails
-                            return AdminsTestsUtil.assertDeleteGlobalAdminFails(globalAdminClient, globalAdminMe.id, 400, callback);
-                        });
+                        // Ensure that the global admin now trying to delete themself (the only
+                        // remaining global admin) fails
+                        return AdminsTestsUtil.assertDeleteGlobalAdminFails(globalAdminClient, globalAdminMe.id, 400, callback);
                     });
                 });
             });
@@ -92,16 +250,29 @@ describe('Admins', function() {
          */
         it('verify validation of deleting a global admin', function(callback) {
             // Create a global administrator to sanity check deletes with
-            TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
-                var username = TestsUtil.generateTestUserId();
-                AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
 
-                    AdminsTestsUtil.assertDeleteGlobalAdminFails(globalAdminClient, 'not an id', 400, function() {
-                        AdminsTestsUtil.assertDeleteGlobalAdminFails(globalAdminClient, '-1', 404, function() {
+                AdminsTestsUtil.assertDeleteGlobalAdminFails(globalAdminClient, 'not an id', 400, function() {
+                    AdminsTestsUtil.assertDeleteGlobalAdminFails(globalAdminClient, '-1', 404, function() {
 
-                            // Sanity check we can delete a global admin
-                            return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
-                        });
+                        // Sanity check we can delete a global admin
+                        return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
+                    });
+                });
+            });
+        });
+
+        it('verify authorization of deleting a global admin', function(callback) {
+            var username = TestsUtil.generateTestUserId();
+            AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
+
+                // Ensure anonymous cannot delete a global admin
+                TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
+                    AdminsTestsUtil.assertDeleteGlobalAdminFails(anonymousGlobalAdminClient, createdGlobalAdmin.id, 401, function() {
+
+                        // Sanity check we can delete the global admin
+                        return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
                     });
                 });
             });

--- a/node_modules/gh-admins/tests/test-admins.js
+++ b/node_modules/gh-admins/tests/test-admins.js
@@ -72,11 +72,9 @@ describe('Admins', function() {
     describe('Me', function() {
 
         it('verify the "me" feed will be anonymous for anonymous users', function(callback) {
-            TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
-                AdminsTestsUtil.assertGetMe(anonymousGlobalAdminClient, function(me) {
-                    AdminsTestsUtil.assertMe(me, {'authenticated': false});
-                    return callback();
-                });
+            AdminsTestsUtil.assertGetMe(anonymousGlobalAdminClient, function(me) {
+                AdminsTestsUtil.assertMe(me, {'authenticated': false});
+                return callback();
             });
         });
 
@@ -116,15 +114,13 @@ describe('Admins', function() {
 
         it('verify authorization of creating a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
-            TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
 
-                // Ensure anonymous can't create a global admin
-                AdminsTestsUtil.assertCreateGlobalAdminFails(anonymousGlobalAdminClient, username, username, username, 401, function(createdGlobalAdmin) {
+            // Ensure anonymous can't create a global admin
+            AdminsTestsUtil.assertCreateGlobalAdminFails(anonymousGlobalAdminClient, username, username, username, 401, function(createdGlobalAdmin) {
 
-                    // Sanity check global admin can create one
-                    AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
-                        return callback();
-                    });
+                // Sanity check global admin can create one
+                AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
+                    return callback();
                 });
             });
         });
@@ -176,17 +172,15 @@ describe('Admins', function() {
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
 
                 // Ensure anonymous user can't update a global admin
-                TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
-                    AdminsTestsUtil.assertUpdateGlobalAdminFails(anonymousGlobalAdminClient, createdGlobalAdmin.id, 'display name', 401, function() {
+                AdminsTestsUtil.assertUpdateGlobalAdminFails(anonymousGlobalAdminClient, createdGlobalAdmin.id, 'display name', 401, function() {
 
-                        // Ensure the created global admin hasn't changed
-                        AdminsTestsUtil.assertGetMe(createdGlobalAdminClient, function(me) {
-                            AdminsTestsUtil.assertMe(me, {'authenticated': createdGlobalAdmin});
+                    // Ensure the created global admin hasn't changed
+                    AdminsTestsUtil.assertGetMe(createdGlobalAdminClient, function(me) {
+                        AdminsTestsUtil.assertMe(me, {'authenticated': createdGlobalAdmin});
 
-                            // Sanity check we can update the created global admin
-                            AdminsTestsUtil.assertUpdateGlobalAdmin(createdGlobalAdminClient, createdGlobalAdmin.id, 'display name', function() {
-                                return callback();
-                            });
+                        // Sanity check we can update the created global admin
+                        AdminsTestsUtil.assertUpdateGlobalAdmin(createdGlobalAdminClient, createdGlobalAdmin.id, 'display name', function() {
+                            return callback();
                         });
                     });
                 });
@@ -268,12 +262,10 @@ describe('Admins', function() {
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {
 
                 // Ensure anonymous cannot delete a global admin
-                TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
-                    AdminsTestsUtil.assertDeleteGlobalAdminFails(anonymousGlobalAdminClient, createdGlobalAdmin.id, 401, function() {
+                AdminsTestsUtil.assertDeleteGlobalAdminFails(anonymousGlobalAdminClient, createdGlobalAdmin.id, 401, function() {
 
-                        // Sanity check we can delete the global admin
-                        return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
-                    });
+                    // Sanity check we can delete the global admin
+                    return AdminsTestsUtil.assertDeleteGlobalAdmin(globalAdminClient, createdGlobalAdmin.id, callback);
                 });
             });
         });

--- a/node_modules/gh-admins/tests/test-admins.js
+++ b/node_modules/gh-admins/tests/test-admins.js
@@ -42,6 +42,9 @@ describe('Admins', function() {
 
     describe('Get Global Admins', function() {
 
+        /**
+         * Test that verifies a list of global admins can be fetched
+         */
         it('verify a list of global admins can be fetched', function(callback) {
             // Ensure we have more than 1 global admin to test with
             AdminsTestsUtil.assertGetMe(globalAdminClient, function(globalAdmin) {
@@ -63,6 +66,9 @@ describe('Admins', function() {
             });
         });
 
+        /**
+         * Test that verifies the authorization of getting a list of global admins
+         */
         it('verify authorization of getting a list of global admins', function(callback) {
             // Ensure anonymous user cannot get global admin list
             return AdminsTestsUtil.assertGetGlobalAdminsFails(anonymousGlobalAdminClient, null, 401, callback);
@@ -71,6 +77,9 @@ describe('Admins', function() {
 
     describe('Me', function() {
 
+        /**
+         * Test that verifies the "me" feed will be anonymous for anonymous users
+         */
         it('verify the "me" feed will be anonymous for anonymous users', function(callback) {
             AdminsTestsUtil.assertGetMe(anonymousGlobalAdminClient, function(me) {
                 AdminsTestsUtil.assertMe(me, {'authenticated': false});
@@ -78,7 +87,10 @@ describe('Admins', function() {
             });
         });
 
-        it('verify the "me" feed will specify the expected admins profile information', function(callback) {
+        /**
+         * Test that verifies the "me" feed will specify the expected admin's profile information
+         */
+        it('verify the "me" feed will specify the expected admin\'s profile information', function(callback) {
             var username = TestsUtil.generateTestUserId();
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
 
@@ -93,6 +105,9 @@ describe('Admins', function() {
 
     describe('Create', function() {
 
+        /**
+         * Test that verifies the validation of creating a global admin
+         */
         it('verify validation of creating a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
 
@@ -112,6 +127,9 @@ describe('Admins', function() {
             });
         });
 
+        /**
+         * Test that verifies the authorization of creating a global admin
+         */
         it('verify authorization of creating a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
 
@@ -128,6 +146,9 @@ describe('Admins', function() {
 
     describe('Update', function() {
 
+        /**
+         * Test that verifies a global admin can be updated
+         */
         it('verify updating a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
@@ -141,6 +162,9 @@ describe('Admins', function() {
             });
         });
 
+        /**
+         * Test that verifies the validation of updating a global admin
+         */
         it('verify validation of updating a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
@@ -167,6 +191,9 @@ describe('Admins', function() {
             });
         });
 
+        /**
+         * Test that verifies the authorization of updating a global admin
+         */
         it('verify authorization of updating a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin, createdGlobalAdminClient) {
@@ -257,6 +284,9 @@ describe('Admins', function() {
             });
         });
 
+        /**
+         * Test that verifies the authorization of deleting a global admin
+         */
         it('verify authorization of deleting a global admin', function(callback) {
             var username = TestsUtil.generateTestUserId();
             AdminsTestsUtil.assertCreateGlobalAdmin(globalAdminClient, username, username, username, function(createdGlobalAdmin) {

--- a/node_modules/gh-admins/tests/util.js
+++ b/node_modules/gh-admins/tests/util.js
@@ -26,72 +26,70 @@ var TestsUtil = require('gh-tests/lib/util');
 /**
  * Ensure the global admin passes all provided assertions
  *
- * @param  {GlobalAdmin}    globalAdmin             The global admin on which to perform assertions
- * @param  {Object}         assertions              An object specifying the assertions to perform
- * @param  {Object}         [assertions.equals]     Perform a strict equality check on the global admin with the given object
- * @param  {Boolean}        [assertions.exists]     Specifies if the global admin should exist (i.e., not be falsey)
- * @param  {Object}         [assertions.has]        Specifies individual properties (an incomplete set of property assertions) that should exist and have a specified value
- * @param  {String[]}       [assertions.missing]    Specifies property keys that should not be present on the global admin
- * @throws {AssertionError}                         Thrown if any of the specified assertions fail
+ * @see TestsUtil#createAssertionFunction for more information
+ *
+ * @param  {GlobalAdmin}    globalAdmin     The global admin on which to perform assertions
+ * @param  {Object}         assertions      An object specifying the assertions to perform
+ * @throws {AssertionError}                 Thrown if any of the specified assertions fail
  */
-var assertGlobalAdmin = module.exports.assertGlobalAdmin = function(globalAdmin, assertions) {
-    if (_.isEmpty(assertions)) {
-        assert.fail('Expected at least one assertion');
-    }
+var assertGlobalAdmin = module.exports.assertGlobalAdmin = TestsUtil.createAssertionFunction();
 
-    _.each(assertions, function(val, name) {
-        if (name === 'equals') {
-            // Equality assertion, ensure the global admin shares all the properties of the `val`
-            assert.deepEqual(globalAdmin, val, 'Expected global admin to be equal, but it was different');
-        } else if (name === 'exists') {
-            // Existential assertion, just ensure the global admin is truthy
-            if (val) {
-                assert.ok(globalAdmin, 'Expected global admin to exist, but it was falsey');
-            } else {
-                assert.ok(!globalAdmin, 'Expected global admin to be falsey, but it existed');
-            }
-        } else if (name === 'has') {
-            _.each(val, function(val, key) {
-                assert.strictEqual(globalAdmin[key], val, util.format('Expected "%s" to equal "%s" but it was different', key, val));
-            });
-        } else if (name === 'missing') {
-            var invalidKeys = _.chain(globalAdmin)
-                .keys()
-                .intersection(val)
-                .value();
-            assert.ok(_.isEmpty(invalidKeys), util.format('Invalid keys existed on global admin profile: "%s"', invalidKeys.join('", "')));
+/**
+ * Ensure the me feed passes all provided assertions
+ *
+ * @see TestsUtil#createAssertionFunction for more information
+ *
+ * @param  {Me}             me          The global admin on which to perform assertions
+ * @param  {Object}         assertions  An object specifying the assertions to perform
+ * @throws {AssertionError}             Thrown if any of the specified assertions fail
+ */
+var assertMe = module.exports.assertMe = TestsUtil.createAssertionFunction({
+    /*!
+     * Ensure that the Me feed has the expected authentication state
+     *
+     * @param  {Me}             actual      The Me feed to test
+     * @param  {GlobalAdmin}    expected    If `falsey`, will ensure the me feed is anonymous. If a global admin, will ensure the me feed indicates it is authenticated as the provided admin
+     */
+    'authenticated': function(actual, globalAdmin) {
+        // Extend the 'has' assertion to ensure the me feed is anonymous in the falsey case
+        if (!globalAdmin) {
+            assertMe(actual, {'has': {'anon': true}});
         } else {
-            assert.fail('Invalid assertion name specified');
+            assertMe(actual, {'has': _.pick(globalAdmin, 'id', 'displayName', 'username')});
         }
-    });
-};
+    }
+});
 
 /**
  * Get all global admins available. This automatically pages through the global admins if there are
  * more than expected on the first page
  *
- * @param  {RestClient}     client                  The REST client to make the request with
- * @param  {Object}         opts                    Optional arguments
- * @param  {Number}         opts.batchSize          The size of batches for the paging requests
- * @param  {Function}       callback                Invoked when all global admins have been fetched
- * @param  {GlobalAdmin[]}  callback.globalAdmins   All global admins in the system
- * @throws {AssertionError}                         Thrown if any request or assertions fail
+ * @param  {RestClient}         client                  The REST client to make the request with
+ * @param  {Object}             opts                    Optional arguments
+ * @param  {Number}             opts.batchSize          The size of batches for the paging requests
+ * @param  {Function}           callback                Invoked when all global admins have been fetched
+ * @param  {GlobalAdmin[]}      callback.globalAdmins   All global admins in the system
+ * @param  {GlobalAdminList[]}  callback.responses      All global admin list responses that were fetched to build the resulting list
+ * @throws {AssertionError}                             Thrown if any request or assertions fail
  */
 var assertGetAllGlobalAdmins = module.exports.assertGetAllGlobalAdmins = function(client, opts, callback, _allGlobalAdmins, _allResponses, _offset) {
+    _allGlobalAdmins = _allGlobalAdmins || [];
+    _allResponses = _allResponses || [];
     _offset = _offset || 0;
 
     opts = opts || {};
     opts = _.defaults(opts, {'batchSize': 50});
 
     // Get the next page of global admins
-    var requestOpts = {'limit': opts.batchSize, 'start': _offset};
+    var requestOpts = {'limit': opts.batchSize, 'offset': _offset};
     assertGetGlobalAdmins(client, requestOpts, function(response) {
         _allGlobalAdmins = _.union(_allGlobalAdmins, response.rows);
+        _allResponses.push(response);
         if (response.rows.length < opts.batchSize) {
-            return callback(_allGlobalAdmins);
+            return callback(_allGlobalAdmins, _allResponses);
         }
 
-        return assertGetAllGlobalAdmins(client, opts, callback, _allGlobalAdmins, _offset + opts.batchSize);
+        return assertGetAllGlobalAdmins(client, opts, callback, _allGlobalAdmins, _allResponses, _offset + opts.batchSize);
     });
 };
 
@@ -112,8 +110,34 @@ var assertGetGlobalAdmins = module.exports.assertGetGlobalAdmins = function(clie
         assert.ok(!err);
         assert.ok(response);
         assert.ok(_.isNumber(response.count));
+
+        if (opts.limit) {
+            assert.ok(opts.limit >= response.rows.length);
+        }
+
         assert.ok(response.count >= response.rows.length);
         return callback(response);
+    });
+};
+
+/**
+ * Attempt to get a page of global admins in the system, ensuring that the request fails in the
+ * specified manner
+ *
+ * @param  {RestClient}         client              The REST client to make the request with
+ * @param  {Object}             [opts]              Optional parameters
+ * @param  {Number}             [opts.limit]        The maximum number of items to return
+ * @param  {Number}             [opts.offset]       The offset at which to start returning items
+ * @param  {Number}             code                The expected HTTP response code of the request
+ * @param  {Function}           callback            Invoked when the request has failed in the expected manner
+ * @throws {AssertionError}                         Thrown if any request or assertions fail
+ */
+var assertGetGlobalAdminsFails = module.exports.assertGetGlobalAdminsFails = function(client, opts, code, callback) {
+    client.admin.getGlobalAdmins(opts, function(err, response) {
+        assert.ok(err);
+        assert.strictEqual(err.code, code);
+        assert.ok(!response);
+        return callback();
     });
 };
 
@@ -127,6 +151,7 @@ var assertGetGlobalAdmins = module.exports.assertGetGlobalAdmins = function(clie
  * @param  {Function}       callback                Invoked when the global admin is successfully created
  * @param  {Object}         callback.err            An error that occurred, if any
  * @param  {GlobalAdmin}    callback.globalAdmin    The global admin that was created
+ * @param  {RestClient}     callback.client         The authenticated client for the global admin that was created
  * @throws {AssertionError}                         Thrown if any request or assertions fail
  */
 var assertCreateGlobalAdmin = module.exports.assertCreateGlobalAdmin = function(client, username, password, displayName, callback) {
@@ -153,8 +178,94 @@ var assertCreateGlobalAdmin = module.exports.assertCreateGlobalAdmin = function(
                 'missing': ['password']
             });
 
-            return callback(globalAdmin);
+            // Ensure the created global admin can log in
+            TestsUtil.getAnonymousGlobalAdminRestClient(function(createdGlobalAdminClient) {
+                AuthTestsUtil.assertLogin(createdGlobalAdminClient, username, password, function() {
+                    return callback(globalAdmin, createdGlobalAdminClient);
+                });
+            });
         });
+    });
+};
+
+/**
+ * Attempt to create a global administrator, ensuring the request fails in the specified manner
+ *
+ * @param  {RestClient}     client                  The REST client to make the request with
+ * @param  {String}         username                The username of the global administrator
+ * @param  {String}         password                The password of the global administrator
+ * @param  {String}         displayName             The display name of the global administrator
+ * @param  {Number}         code                    The expected HTTP code of the failed request
+ * @param  {Function}       callback                Invoked when the global admin is successfully created
+ * @param  {Object}         callback.err            An error that occurred, if any
+ * @param  {GlobalAdmin}    callback.globalAdmin    The global admin that was created
+ * @throws {AssertionError}                         Thrown if any request or assertions fail
+ */
+var assertCreateGlobalAdminFails = module.exports.assertCreateGlobalAdminFails = function(client, username, password, displayName, code, callback) {
+    // Ensure the create request fails in the expected manner
+    client.admin.createGlobalAdmin(username, password, displayName, function(err, globalAdmin) {
+        assert.ok(err);
+        assert.strictEqual(err.code, code);
+        assertGlobalAdmin(globalAdmin, {'exists': false});
+
+        return callback();
+    });
+};
+
+/**
+ * Update the global admin identified by the given id, ensuring the update is successful
+ *
+ * @param  {RestClient}     client                  The REST client to make the request with
+ * @param  {Number}         id                      The id of the global admin to update
+ * @param  {String}         displayName             The display name with which to update the global admin
+ * @param  {Function}       callback                Invoked when the global admin is successfully updated
+ * @param  {GlobalAdmin}    callback.globalAdmin    The updated version of the global admin
+ * @throws {AssertionError}                         Thrown if any assertions fail
+ */
+var assertUpdateGlobalAdmin = module.exports.assertUpdateGlobalAdmin = function(client, id, displayName, callback) {
+    // Update the global admin, ensuring the resulting updated global admin has the new display name
+    client.admin.updateGlobalAdmin(id, displayName, function(err, updatedGlobalAdmin) {
+        assert.ok(!err);
+        assertGlobalAdmin(updatedGlobalAdmin, {
+            'has': {
+                'id': id,
+                'displayName': displayName
+            },
+            'missing': ['password']
+        });
+
+        // Get the global admin and ensure the persisted copy has the display name
+        assertGetAllGlobalAdmins(client, null, function(globalAdmins) {
+            var globalAdmin = _.findWhere(globalAdmins, {'id': id});
+            assertGlobalAdmin(updatedGlobalAdmin, {
+                'has': {
+                    'id': id,
+                    'displayName': displayName
+                },
+                'missing': ['password']
+            });
+
+            return callback();
+        });
+    });
+};
+
+/**
+ * Attempt to update the global admin, ensuring the request fails in the specified manner
+ *
+ * @param  {RestClient}     client                  The REST client to make the request with
+ * @param  {Number}         id                      The id of the global admin to update
+ * @param  {String}         displayName             The display name with which to update the global admin
+ * @param  {Number}         code                    The expected HTTP code of the failed request
+ * @param  {Function}       callback                Invoked when the global admin fails to update
+ * @throws {AssertionError}                         Thrown if any assertions fail
+ */
+var assertUpdateGlobalAdminFails = module.exports.assertUpdateGlobalAdminFails = function(client, id, displayName, code, callback) {
+    client.admin.updateGlobalAdmin(id, displayName, function(err, updatedGlobalAdmin) {
+        assert.ok(err);
+        assert.strictEqual(err.code, code);
+        assertGlobalAdmin(updatedGlobalAdmin, {'exists': false});
+        return callback();
     });
 };
 
@@ -188,21 +299,26 @@ var assertDeleteGlobalAdmins = module.exports.assertDeleteGlobalAdmins = functio
  * @throws {AssertionError}                         Thrown if any request or assertions fail
  */
 var assertDeleteGlobalAdmin = module.exports.assertDeleteGlobalAdmin = function(client, id, callback) {
-    // Get the global admin user we're about to delete
-    assertGetAllGlobalAdmins(client, null, function(globalAdmins) {
-        var globalAdmin = _.findWhere(globalAdmins, {'id': id});
+    // Get a global admin client for a global admin that we never delete. That way we can use it
+    // to perform post-delete assertions on data
+    TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
 
-        // Delete the global admin
-        client.admin.deleteGlobalAdmin(id, function(err) {
-            assert.ok(!err);
+        // Get the global admin user we're about to delete
+        assertGetAllGlobalAdmins(client, null, function(globalAdmins) {
+            var globalAdmin = _.findWhere(globalAdmins, {'id': id});
 
-            // Ensure the global admin no longer exists
-            assertGetAllGlobalAdmins(client, null, function(globalAdmins) {
-                assertGlobalAdmin(_.findWhere(globalAdmins, {'id': id}), {'exists': false});
+            // Delete the global admin
+            client.admin.deleteGlobalAdmin(id, function(err) {
+                assert.ok(!err);
 
-                // Ensure we can no longer authenticate as this global admin
-                TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousClient) {
-                    return AuthTestsUtil.assertLoginFails(anonymousClient, globalAdmin.username, globalAdmin.password, callback);
+                // Ensure the global admin no longer exists
+                assertGetAllGlobalAdmins(globalAdminClient, null, function(globalAdmins) {
+                    assertGlobalAdmin(_.findWhere(globalAdmins, {'id': id}), {'exists': false});
+
+                    // Ensure we can no longer authenticate as this global admin
+                    TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousClient) {
+                        return AuthTestsUtil.assertLoginFails(anonymousClient, globalAdmin.username, globalAdmin.password, callback);
+                    });
                 });
             });
         });
@@ -230,9 +346,10 @@ var assertDeleteGlobalAdminFails = module.exports.assertDeleteGlobalAdminFails =
  * Get the "me" object of the currently authenticated user, assuming we have a global administrator
  * authenticated
  *
- * @param  {RestClient}     client      The REST client to make the request with
- * @param  {Function}       callback    Invoked when all assertions succeed
- * @throws {AssertionError}             Thrown if any request or assertions fail
+ * @param  {RestClient}     client          The REST client to make the request with
+ * @param  {Function}       callback        Invoked when all assertions succeed
+ * @param  {Me}             callback.me     The me feed that was fetched
+ * @throws {AssertionError}                 Thrown if any request or assertions fail
  */
 var assertGetMe = module.exports.assertGetMe = function(client, callback) {
     client.admin.getMe(function(err, me) {

--- a/node_modules/gh-auth/lib/api.js
+++ b/node_modules/gh-auth/lib/api.js
@@ -277,7 +277,6 @@ var contextMiddleware = function(req, res, next) {
     }
 
     // TODO: Add imposter
-
     req.ctx = new Context(req.ghApp, user);
     return next();
 };

--- a/node_modules/gh-auth/lib/util.js
+++ b/node_modules/gh-auth/lib/util.js
@@ -68,9 +68,9 @@ var validateRedirectUrl = module.exports.validateRedirectUrl = function(redirect
     // so that we're not sending the user to a remote site. We do this by resolving
     // the redirect URL as the browser would. If the domain is not the same, some
     // tampering is going on
-    var resolvedUrl = url.resolve('http://grasshopper.com', redirectUrl);
+    var resolvedUrl = url.resolve('http://grasshopper.local', redirectUrl);
     var parsedUrl = url.parse(resolvedUrl);
-    if (parsedUrl.hostname !== 'grasshopper.com') {
+    if (parsedUrl.hostname !== 'grasshopper.local') {
         redirectUrl = '/';
         log().warn({'redirectUrl': redirectUrl}, 'Possible Open Redirect attack detected');
     }

--- a/node_modules/gh-auth/tests/util.js
+++ b/node_modules/gh-auth/tests/util.js
@@ -104,7 +104,7 @@ var assertShibbolethApplicationRedirect = module.exports.assertShibbolethApplica
 
         // Verify we're being redirected to our Shibboleth application
         assert.ok(_.has(response.headers, 'location'));
-        assert.strictEqual(response.headers.location.indexOf('https://shib-sp.grasshopper.com'), 0);
+        assert.strictEqual(response.headers.location.indexOf('https://shib-sp.grasshopper.local'), 0);
 
         // Get the parameters that need to be sent to the Shibboleth application
         var params = url.parse(response.headers.location, true).query;

--- a/node_modules/gh-auth/tests/util.js
+++ b/node_modules/gh-auth/tests/util.js
@@ -19,6 +19,7 @@
 var _ = require('lodash');
 var assert = require('assert');
 var url = require('url');
+var util = require('util');
 
 var TestsUtil = require('gh-tests/lib/util');
 var UsersTestsUtil = require('gh-users/tests/util');
@@ -103,8 +104,9 @@ var assertShibbolethApplicationRedirect = module.exports.assertShibbolethApplica
         assert.ok(!err);
 
         // Verify we're being redirected to our Shibboleth application
+        var shibHost = TestsUtil.getConfig().servers.shibbolethSPHost;
         assert.ok(_.has(response.headers, 'location'));
-        assert.strictEqual(response.headers.location.indexOf('https://shib-sp.grasshopper.local'), 0);
+        assert.strictEqual(response.headers.location.indexOf(util.format('https://%s', shibHost)), 0);
 
         // Get the parameters that need to be sent to the Shibboleth application
         var params = url.parse(response.headers.location, true).query;

--- a/node_modules/gh-auth/tests/util.js
+++ b/node_modules/gh-auth/tests/util.js
@@ -53,15 +53,16 @@ var assertLogin = module.exports.assertLogin = function(client, username, passwo
  * @param  {Function}       callback                Standard callback function
  */
 var assertLoginFails = module.exports.assertLoginFails = function(client, username, password, callback) {
-    client.auth.login(username, password, function(err, body, response) {
-        assert.ok(err);
-        assert.strictEqual(err.code, 401);
+    // Get the me feed before trying to log in so we know what our session was like before
+    UsersTestsUtil.assertGetMe(client, function(meBefore) {
 
-        // Verify we're not logged in
-        client.user.getMe(function(err, body, response) {
-            assert.ok(!err);
-            assert.strictEqual(body.anon, true);
-            return callback();
+        // Attempt to log in, ensuring it fails
+        client.auth.login(username, password, function(err, body, response) {
+            assert.ok(err);
+            assert.strictEqual(err.code, 401);
+
+            // Get the me feed again, ensuring our session hasn't changed
+            return UsersTestsUtil.assertGetMeEquals(client, meBefore, callback);
         });
     });
 };

--- a/node_modules/gh-calendar/lib/util.js
+++ b/node_modules/gh-calendar/lib/util.js
@@ -24,9 +24,19 @@ var VTodo = require('cozy-ical').VTodo;
 /**
  * Format a set of events into an iCalendar feed
  *
- * @param  {CalendarInfo}   calendarInfo    More information about the calendar
- * @param  {Event[]}        events          The events that should be in the iCalendar feed
- * @return {String}                         The iCalendar feed
+ * @param  {CalendarInfo}       calendarInfo            More information about the calendar
+ * @param  {Object[]}           events                  A subset of event data, depending on what the consumer decided to provide
+ * @param  {Number}             events.id               The id of the event
+ * @param  {String}             events.start            The timestamp (ISO 8601) at which the event starts
+ * @param  {String}             events.end              The timestamp (ISO 8601) at which the event ends
+ * @param  {String}             events.createdAt        The timestamp (ISO 8601) at which the event was created
+ * @param  {String}             [events.updatedAt]      The timestamp (ISO 8601) at which the event was last updated
+ * @param  {String}             [events.location]       The location of the event
+ * @param  {String}             [events.type]           The type of the event
+ * @param  {String[]|User[]}    [events.organisers]     The organiser(s) of the event, if any
+ * @param  {String}             [events.description]    The description of the event
+ * @param  {String}             [events.notes]          The general notes of the event
+ * @return {String}                                     The iCalendar feed
  */
 var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) {
     // Construct a calendar
@@ -45,10 +55,12 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
         // stringified `null` entries or blank lines
         var description = '';
 
-        // Only add the type is there is any
+        // Only add the type if there is one
         if (event.type) {
             description += event.type;
         }
+
+        // Only add organisers if there are any
         if (!_.isEmpty(event.organisers)) {
             var organisers = _.chain(event.organisers)
                 .sort()
@@ -63,6 +75,13 @@ var eventsToICal = module.exports.eventsToICal = function(calendarInfo, events) 
                 .join(', ');
             description += ' with ' + organisers;
         }
+
+        // Only add the description if there is one
+        if (event.description) {
+            description += '\n' + event.description;
+        }
+
+        // Only add events notes if there are any
         if (event.notes) {
             description += '\n\n' + event.notes;
         }

--- a/node_modules/gh-core/lib/server.js
+++ b/node_modules/gh-core/lib/server.js
@@ -243,7 +243,7 @@ var postInitialize = module.exports.postInitialize = function(app, router) {
      * If using a utility such as `curl` to POST requests to the API, you can bypass this by just setting the referer
      * header to "/":
      *
-     * curl -X POST -e / http://my.grasshopper.com/api/auth/login
+     * curl -X POST -e / http://my.grasshopper.local/api/auth/login
      *
      * More information about CSRF attacks: http://en.wikipedia.org/wiki/Cross-site_request_forgery
      */

--- a/node_modules/gh-core/lib/server.js
+++ b/node_modules/gh-core/lib/server.js
@@ -86,7 +86,12 @@ var setUpServer = module.exports.setUpServer = function(port, config) {
 
             // Track the time and response code for the route
             var requestName = 'http.' + req.method + '.' + url;
-            var statsd = StatsdAPI.getInstance(req.ctx.app.id);
+
+            // In situations where a request fails before we've had a chance to bind a Context, we
+            // need to find a way to still get meaningful information to statsd. Use app id -1 as
+            // a way to indicate there was no app information available
+            var appId = (req.ctx && req.ctx.app && req.ctx.app.id) || -1;
+            var statsd = StatsdAPI.getInstance(appId);
             statsd.increment(requestName + '.' + code + '.count');
             statsd.timing(requestName + '.time', Date.now() - start);
 

--- a/node_modules/gh-events/lib/internal/dao.js
+++ b/node_modules/gh-events/lib/internal/dao.js
@@ -53,6 +53,7 @@ var createEvent = module.exports.createEvent = function(appId, displayName, star
         'start': start,
         'type': opts.type
     };
+
     DB.Event.create(event).complete(function(err, event) {
         if (err) {
             log().error({'err': err}, 'Failed to create a new event');

--- a/node_modules/gh-events/lib/rest.js
+++ b/node_modules/gh-events/lib/rest.js
@@ -101,6 +101,7 @@ var createEvent = function(req, res) {
         'series': GrasshopperUtil.toArray(req.body.series),
         'type': req.body.type
     };
+
     EventsAPI.createEvent(req.ctx, req.body.app, req.body.displayName, req.body.start, req.body.end, opts, function(err, event) {
         if (err) {
             return res.status(err.code).send(err.msg);

--- a/node_modules/gh-events/tests/util.js
+++ b/node_modules/gh-events/tests/util.js
@@ -362,7 +362,9 @@ var generateTestEvents = module.exports.generateTestEvents = function(client, to
 
     // Create the event
     var displayName = TestsUtil.generateString(30);
+    var description = TestsUtil.generateString(60);
     var opts = {
+        'description': description,
         'location': _.sample(LOCATIONS),
         'organiserOther': [_.sample(ORGANISERS)],
         'type': TestsUtil.generateString(15)

--- a/node_modules/gh-tests/lib/util.js
+++ b/node_modules/gh-tests/lib/util.js
@@ -561,3 +561,84 @@ var parseIcalCalendar = module.exports.parseIcalCalendar = function(calendar, ca
         return callback(calendar);
     });
 };
+
+/**
+ * Create a function that can invoke a standard set of assertions for some type of generic object.
+ * The returned function will accept some actual data (e.g., a server response) and a set of
+ * assertions that the consumer wants to perform, along with some set of expected data. If any
+ * assertions fail, an `AssertionError` is thrown from the assertion function. The following generic
+ * assertions are provided for you:
+ *
+ *  * 'equals': Performs an `assert.deepEqual` on the actual data and the expected data
+ *  * 'exists': When truthy, ensures the actual data is truthy. When falsey, ensures the actual data is falsey
+ *  * 'has': Given an object of arbitrary keys and values, ensures that all keys and expected values are present on the actual data object. Similar to 'equals' but allows one to assert partial data
+ *  * 'missing': Given an array of strings, ensures the actual data contains of the strings as keys
+ *
+ * To override any of the generic assertion methods, simply provide a custom assertion function with
+ * the same assertion name and it will be overridden.
+ *
+ * @param  {Object}     customAssertionFunctions        An object keyed by "assertion name" whose value is a function that takes the expected data, actual data, and allows you to run custom assertions
+ * @return {Function}   assertionFunction               The assertion function that can be used in tests
+ *         {Object}     assertionFunction.actualData    Represents the "actual" data object you wish to run assertions on
+ *         {Object}     assertionFunction.assertions    An object keyed by assertion type (e.g., 'equals'), whose value is the assertion-specific data (usually "expected" data)
+ */
+var createAssertionFunction = module.exports.createAssertionFunction = function(customAssertionFunctions) {
+    customAssertionFunctions = customAssertionFunctions || {};
+
+    // Create our set of default generic assertion functions that are handy for most cases. See
+    // function summary for more information about what these functions do
+    var defaultAssertionFunctions = {
+        'equals': assert.deepEqual,
+        'exists': function(actual, exists) {
+            if (exists) {
+                assert.ok(actual);
+            } else {
+                assert.ok(!actual);
+            }
+        },
+        'has': function(actual, expectedFieldValues) {
+            if (_.isEmpty(expectedFieldValues)) {
+                assert.fail('Expected to assert the value of at least one field');
+            }
+
+            _.each(expectedFieldValues, function(value, key) {
+                assert.strictEqual(actual[key], value);
+            });
+        },
+        'missing': function(actual, missingKeys) {
+            if (!_.isArray(missingKeys) || _.isEmpty(missingKeys)) {
+                assert.fail('Expected a non-empty array of missing keys to test');
+            }
+
+            var invalidKeys = _.chain(actual)
+                .keys()
+                .intersection(missingKeys)
+                .value();
+            assert.ok(_.isEmpty(invalidKeys), util.format('Invalid keys existed on actual object: "%s"', invalidKeys.join('", "')));
+        }
+    };
+
+    // Overlay the default assertion functions onto the provided custom assertion functions
+    var assertionFunctions = _.defaults(customAssertionFunctions, defaultAssertionFunctions);
+
+    return function(actualData, assertions) {
+        if (_.isEmpty(assertions)) {
+            // There should always be at least one assertion
+            assert.fail('Expected at least one assertion to perform');
+        }
+
+        // Run each assertion that was specified by the consumer with the expected assertion data.
+        // The actual meaning of the data is dependent on the assertion implementation in
+        // `assertionFunctions`
+        _.each(assertions, function(expectedData, name) {
+            var assertionFunction = assertionFunctions[name];
+            if (!_.isFunction(assertionFunction)) {
+                // Fail hard if the consumer specified an assertion that doesn't have any
+                // functionality associated to it
+                assert.fail(util.format('Invalid assertion specified with name "%s"', name));
+            }
+
+            assertionFunction(actualData, expectedData);
+        });
+    };
+};

--- a/node_modules/gh-tests/lib/util.js
+++ b/node_modules/gh-tests/lib/util.js
@@ -28,6 +28,8 @@ var Grasshopper = require('gh-core');
 var RestAPI = require('gh-rest');
 var RestUtil = require('gh-rest/lib/util');
 
+var _config = null;
+
 /**
  * Create the initial test configuration
  *
@@ -67,6 +69,10 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
  * @param  {Function}    callback       Standard callback function
  */
 var setUpBeforeTests = module.exports.setUpBeforeTests = function(config, callback) {
+
+    // Set the config so it can be accessed elsewhere in the application
+    _config = config;
+
     // Initialize the core container
     Grasshopper.init(config, function(err) {
         if (err) {
@@ -219,6 +225,15 @@ var createDefaultTestApp = function(globalAdminRestClient, tenant, hostSuffix, y
 };
 
 /**
+ * Get the application configuration used for the test suite
+ *
+ * @return {Config}                The application configuration
+ */
+var getConfig = module.exports.getConfig = function() {
+    return _config;
+};
+
+/**
  * Get an anonymous global administrator REST client
  *
  * @param  {Function}       callback                    Standard callback function
@@ -227,7 +242,7 @@ var createDefaultTestApp = function(globalAdminRestClient, tenant, hostSuffix, y
 var getAnonymousGlobalAdminRestClient = module.exports.getAnonymousGlobalAdminRestClient = function(callback) {
     var options = {
         'host': 'localhost:2000',
-        'hostHeader': 'admin.grasshopper.local'
+        'hostHeader': getConfig().servers.adminHostname
     };
     RestAPI.createClient(options, function(err, client) {
         assert.ok(!err);
@@ -244,7 +259,7 @@ var getAnonymousGlobalAdminRestClient = module.exports.getAnonymousGlobalAdminRe
 var getGlobalAdminRestClient = module.exports.getGlobalAdminRestClient = function(callback) {
     var options = {
         'host': 'localhost:2000',
-        'hostHeader': 'admin.grasshopper.local',
+        'hostHeader': getConfig().servers.adminHostname,
         'authenticationStrategy': 'local',
         'username': 'administrator',
         'password': 'administrator'
@@ -263,7 +278,7 @@ var getGlobalAdminRestClient = module.exports.getGlobalAdminRestClient = functio
 var getGlobalAdminApp = module.exports.getGlobalAdminApp = function() {
     return {
         'displayName': 'Global admin server',
-        'host': 'admin.grasshopper.local',
+        'host': getConfig().servers.adminHostname,
         'isGlobalAdmin': true
     };
 };
@@ -277,7 +292,7 @@ var getGlobalAdminApp = module.exports.getGlobalAdminApp = function() {
 var getShibbolethRestClient = module.exports.getShibbolethRestClient = function(callback) {
     var options = {
         'host': 'localhost:2001',
-        'hostHeader': 'shib-sp.grasshopper.local'
+        'hostHeader': getConfig().servers.shibbolethSPHost
     };
     RestAPI.createClient(options, function(err, client) {
         assert.ok(!err);

--- a/node_modules/gh-tests/lib/util.js
+++ b/node_modules/gh-tests/lib/util.js
@@ -54,7 +54,6 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
     config.db.dropOnStartup = true;
 
     // Ensure that the tests always run on the correct hostname/ports
-    config.servers.adminHostname = 'admin.grasshopper.com';
     config.servers.adminPort = 2000;
     config.servers.appsPort = 2001;
 
@@ -68,6 +67,7 @@ var createInitialTestConfig = module.exports.createInitialTestConfig = function(
  * @param  {Function}    callback       Standard callback function
  */
 var setUpBeforeTests = module.exports.setUpBeforeTests = function(config, callback) {
+    // Initialize the core container
     Grasshopper.init(config, function(err) {
         if (err) {
             return callback(new Error(err.msg));
@@ -227,7 +227,7 @@ var createDefaultTestApp = function(globalAdminRestClient, tenant, hostSuffix, y
 var getAnonymousGlobalAdminRestClient = module.exports.getAnonymousGlobalAdminRestClient = function(callback) {
     var options = {
         'host': 'localhost:2000',
-        'hostHeader': 'admin.grasshopper.com'
+        'hostHeader': 'admin.grasshopper.local'
     };
     RestAPI.createClient(options, function(err, client) {
         assert.ok(!err);
@@ -244,7 +244,7 @@ var getAnonymousGlobalAdminRestClient = module.exports.getAnonymousGlobalAdminRe
 var getGlobalAdminRestClient = module.exports.getGlobalAdminRestClient = function(callback) {
     var options = {
         'host': 'localhost:2000',
-        'hostHeader': 'admin.grasshopper.com',
+        'hostHeader': 'admin.grasshopper.local',
         'authenticationStrategy': 'local',
         'username': 'administrator',
         'password': 'administrator'
@@ -263,7 +263,7 @@ var getGlobalAdminRestClient = module.exports.getGlobalAdminRestClient = functio
 var getGlobalAdminApp = module.exports.getGlobalAdminApp = function() {
     return {
         'displayName': 'Global admin server',
-        'host': 'admin.grasshopper.com',
+        'host': 'admin.grasshopper.local',
         'isGlobalAdmin': true
     };
 };
@@ -277,7 +277,7 @@ var getGlobalAdminApp = module.exports.getGlobalAdminApp = function() {
 var getShibbolethRestClient = module.exports.getShibbolethRestClient = function(callback) {
     var options = {
         'host': 'localhost:2001',
-        'hostHeader': 'shib-sp.grasshopper.com'
+        'hostHeader': 'shib-sp.grasshopper.local'
     };
     RestAPI.createClient(options, function(err, client) {
         assert.ok(!err);
@@ -334,7 +334,7 @@ var generateTestTenant = module.exports.generateTestTenant = function(nrOfApps, 
             // Create a number of applications
             _.times(nrOfApps, function(n) {
                 var appDisplayName = util.format('%s %d', tenantDisplayName, n);
-                var host = util.format('%d.%s.grasshopper.com', n, tenantDisplayName);
+                var host = util.format('%d.%s.grasshopper.local', n, tenantDisplayName);
                 _generateTestApp(globalAdminClient, tenant.id, appDisplayName, host, function(app) {
                     args.push(app);
                     return done();

--- a/node_modules/gh-users/lib/internal/dao.js
+++ b/node_modules/gh-users/lib/internal/dao.js
@@ -363,7 +363,7 @@ var generateCalendarToken = module.exports.generateCalendarToken = function() {
  * @param  {String}     [end]               The timestamp (ISO 8601) until which to get the calendar for the user
  * @param  {Function}   callback            Standard callback function
  * @param  {Object}     callback.err        An error object, if any
- * @param  {Event[]}    callback.events     The events in a user's calendar
+ * @param  {Object[]}   callback.events     A subset of event data properties: id, displayName, start, end, location, type, description, notes, organiserOther, updatedAt
  */
 var getUserCalendar = module.exports.getUserCalendar = function(user, includeContext, start, end, callback) {
     var dateTimeFilter = {};
@@ -374,16 +374,13 @@ var getUserCalendar = module.exports.getUserCalendar = function(user, includeCon
         dateTimeFilter.end = {'lte': end};
     }
 
-    // This query fetches such a massive amount of data, that the CPU usage
-    // goes through the roof when Sequelize serialises it. To minimise this,
-    // we retrieve only those columns we really need
-    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'type', 'notes', 'organiserOther', 'updatedAt'];
+    // This query fetches such a massive amount of data, that the CPU usage goes through the roof
+    // when Sequelize serialises it. To minimise this, we retrieve only those columns we really need
+    var eventFields = ['id', 'displayName', 'start', 'end', 'location', 'type', 'description', 'notes', 'organiserOther', 'updatedAt'];
     var userFields = ['id', 'displayName'];
 
     var options = {
-        // Adding `required` into the model inclusions forces Sequelize to use a
-        // `left outer join` to connect the Serie/Events. If these were to be omitted,
-        // Sequelize would use an `inner join` which would always result in 0 rows
+        // Do an outer join (`'required': false`) since many of the relations are optional
         'include': [
             {'model': DB.CalendarSeries, 'required': false, 'include': [
                 {'model': DB.Serie, 'required': false, 'limit': null, 'attributes': ['id'], 'include': [

--- a/node_modules/gh-users/tests/test-calendar.js
+++ b/node_modules/gh-users/tests/test-calendar.js
@@ -416,23 +416,26 @@ describe('Users - calendars', function() {
          * Check that the correct description is returned in the iCal feeds
          *
          * @param  {Object}     user                    The user client and profile that can be used to retrieve the iCal feed
-         * @param  {Serie}      serie                   The serie to which the event needs to be added
+         * @param  {Series}     series                  The series to which the event needs to be added
          * @param  {String[]}   [organisers]            A set of organisers for the event
          * @param  {String}     [type]                  The event type
+         * @param  {String}     [description]           The event description
          * @param  {String}     [notes]                 The event notes
          * @param  {String}     expectedDescription     The description that should be returned by the iCal feed
          * @param  {Function}   callback                Standard callback function
          * @throws {AssertionError}                     Error thrown when an assertion failed
          */
-        var checkICalEventDescription = function(user, serie, organisers, type, notes, expectedDescription, callback) {
+        var checkICalEventDescription = function(user, series, organisers, type, description, notes, expectedDescription, callback) {
             // Create the event
             var start = moment().subtract(1, 'day').format();
             var end = moment(start).add(60, 'minute').format();
             var opts = {
-                'type': type,
+                'description': description,
                 'notes': notes,
-                'series': [serie.id]
+                'series': [series.id],
+                'type': type
             };
+
             EventsTestsUtil.assertCreateEvent(global.tests.admins.cam2013.client, 'Test event', start, end, opts, function(event) {
 
                 // Ensure the correct organisers are present
@@ -441,7 +444,7 @@ describe('Users - calendars', function() {
                 // Always remove the auto-added one
                 update[global.tests.admins.cam2013.profile.id] = false;
 
-                // Add the specified organisers
+                // Add the specified organisers d
                 _.each(organisers, function(organiser) {
                     update[organiser] = true;
                 });
@@ -480,38 +483,41 @@ describe('Users - calendars', function() {
                         SeriesTestUtil.assertSubscribeSeries(simon.client, serie.id, simon.profile.id, null, function() {
 
                             // Check an event without any type, notes or organiser
-                            checkICalEventDescription(simon, serie, [], null, null, null, function() {
+                            checkICalEventDescription(simon, serie, [], null, null, null, null, function() {
 
-                                // Check an event with only a type but no notes or organisers
-                                checkICalEventDescription(simon, serie, [], 'Lab', null, 'Lab', function() {
+                                // Check an event with only a type but no description, notes or organisers
+                                checkICalEventDescription(simon, serie, [], 'Lab', null, null, 'Lab', function() {
 
-                                    // Check an event with only some notes but no type or organisers
-                                    checkICalEventDescription(simon, serie, [], null, 'bring paper', 'bring paper', function() {
+                                    // Check an event with only some notes but no type, description or organisers
+                                    checkICalEventDescription(simon, serie, [], null, null, 'bring paper', 'bring paper', function() {
 
-                                        // Check an event with both a type and notes but no organisers
-                                        checkICalEventDescription(simon, serie, [], 'Lab', 'bring paper', 'Lab\n\nbring paper', function() {
+                                        // Check an event with both a type and notes but no description or organisers
+                                        checkICalEventDescription(simon, serie, [], 'Lab', null, 'bring paper', 'Lab\n\nbring paper', function() {
 
-                                            // Check an event with some organisers, but no type or notes
-                                            checkICalEventDescription(simon, serie, ['Jill'], null, null, 'with Jill', function() {
-                                                checkICalEventDescription(simon, serie, ['Jill', 'Jack'], null, null, 'with Jack, Jill', function() {
-                                                    checkICalEventDescription(simon, serie, ['Jack', 'Jill'], null, null, 'with Jack, Jill', function() {
+                                            // Check an event with some organisers, but no type, description  or notes
+                                            checkICalEventDescription(simon, serie, ['Jill'], null, null, null, 'with Jill', function() {
+                                                checkICalEventDescription(simon, serie, ['Jill', 'Jack'], null, null, null, 'with Jack, Jill', function() {
+                                                    checkICalEventDescription(simon, serie, ['Jack', 'Jill'], null, null, null, 'with Jack, Jill', function() {
 
-                                                        // Check an event with some organisers and a type but no notes
-                                                        checkICalEventDescription(simon, serie, ['Jill'], 'Lab', null, 'Lab with Jill', function() {
-                                                            checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', null, 'Lab with Jack, Jill', function() {
-                                                                checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', null, 'Lab with Jack, Jill', function() {
+                                                        // Check an event with some organisers and a type but no description or notes
+                                                        checkICalEventDescription(simon, serie, ['Jill'], 'Lab', null, null, 'Lab with Jill', function() {
+                                                            checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', null, null, 'Lab with Jack, Jill', function() {
+                                                                checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', null, null, 'Lab with Jack, Jill', function() {
 
-                                                                    // Check an event with some organisers and some notes but no type
-                                                                    checkICalEventDescription(simon, serie, ['Jill'], null, 'bring paper', 'with Jill\n\nbring paper', function() {
-                                                                        checkICalEventDescription(simon, serie, ['Jill', 'Jack'], null, 'bring paper', 'with Jack, Jill\n\nbring paper', function() {
-                                                                            checkICalEventDescription(simon, serie, ['Jack', 'Jill'], null, 'bring paper', 'with Jack, Jill\n\nbring paper', function() {
+                                                                    // Check an event with some organisers and some notes but no type or description
+                                                                    checkICalEventDescription(simon, serie, ['Jill'], null, null, 'bring paper', 'with Jill\n\nbring paper', function() {
+                                                                        checkICalEventDescription(simon, serie, ['Jill', 'Jack'], null, null, 'bring paper', 'with Jack, Jill\n\nbring paper', function() {
+                                                                            checkICalEventDescription(simon, serie, ['Jack', 'Jill'], null, null, 'bring paper', 'with Jack, Jill\n\nbring paper', function() {
 
-                                                                                // Check an event with some organisers, a type and some notes
-                                                                                checkICalEventDescription(simon, serie, ['Jill'], 'Lab', 'bring paper', 'Lab with Jill\n\nbring paper', function() {
-                                                                                    checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
-                                                                                        checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
+                                                                                // Check an event with some organisers, a type and some notes, but no description
+                                                                                checkICalEventDescription(simon, serie, ['Jill'], 'Lab', null, 'bring paper', 'Lab with Jill\n\nbring paper', function() {
+                                                                                    checkICalEventDescription(simon, serie, ['Jill', 'Jack'], 'Lab', null, 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
+                                                                                        checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', null, 'bring paper', 'Lab with Jack, Jill\n\nbring paper', function() {
 
-                                                                                            return callback();
+                                                                                            // Check an event with some organisers, a type, a description and some notes
+                                                                                            checkICalEventDescription(simon, serie, ['Jack', 'Jill'], 'Lab', 'this is an awesome event that requires paper', 'bring paper', 'Lab with Jack, Jill\nthis is an awesome event that requires paper\n\nbring paper', function() {
+                                                                                                return callback();
+                                                                                            });
                                                                                         });
                                                                                     });
                                                                                 });

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -52,6 +52,17 @@ var assertUser = module.exports.assertUser = function(user, expectedUser, canVie
 };
 
 /**
+ * Ensure the me object passes all provided assertions
+ *
+ * @see TestsUtil#createAssertionFunction for more information
+ *
+ * @param  {Me}             me          The me object on which to perform assertions
+ * @param  {Object}         assertions  An object specifying the assertions to perform
+ * @throws {AssertionError}             Thrown if any of the specified assertions fail
+ */
+var assertMe = module.exports.assertMe = TestsUtil.createAssertionFunction();
+
+/**
  * Assert that the me feed can be retrieved
  *
  * @param  {RestClient}         client                          The REST client to make the request with
@@ -67,6 +78,21 @@ var assertGetMe = module.exports.assertGetMe = function(client, callback) {
         assert.ok(_.isObject(me.app));
         assert.ok(_.isString(me.app.displayName));
         return callback(me);
+    });
+};
+
+/**
+ * Assert that the me feed can be retrieved and equals the given me feed
+ *
+ * @param  {RestClient}     client          The REST client to make the request with
+ * @param  {Me}             expectedMe      The expected me feed
+ * @param  {Function}       callback        Invoked when the me feed assertions have passed
+ * @throws {AssertionError}                 Error thrown when an assertion failed
+ */
+var assertGetMeEquals = module.exports.assertGetMeEquals = function(client, expectedMe, callback) {
+    assertGetMe(client, function(me) {
+        assertMe(me, {'equals': expectedMe});
+        return callback();
     });
 };
 

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -389,7 +389,7 @@ var assertGetUserCalendar = module.exports.assertGetUserCalendar = function(clie
         }
 
         // Assert only the required information is returned
-        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context', 'type', 'notes'];
+        var allowedEventKeys = ['id', 'displayName', 'location', 'start', 'end', 'organisers', 'updatedAt', 'context', 'type', 'description', 'notes'];
         var allowedContextKeys = ['id', 'ParentId', 'displayName', 'type'];
         _.each(calendar.results, function(event) {
             _.each(event, function(val, key) {


### PR DESCRIPTION
I have a thing using non-obvious sample URLs as sample/default URLs, especially when they resolve to something on the internet, and especially especially when they resolve to what looks to be valid existing company domains.

We can do all the things we need with `/etc/hosts` with `*.local` domains which are more common for things that we intend to resolve locally (e.g., default URLs), so it's better a bit more clear about the intention when we default to `*.local`s.