### PR TITLE
Fix up Sequelize deprecation warning

### DIFF
--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -350,8 +350,8 @@ var _setUpModel = function(sequelize) {
 
     Group.belongsTo(User, {'as': 'LockedBy'});
 
-    Group.hasMany(User, {'as': 'Members', 'through': 'Group_Members'});
-    User.hasMany(Group, {'as': 'Memberships', 'through': 'Group_Members'});
+    Group.belongsToMany(User, {'as': 'Members', 'through': 'Group_Members'});
+    User.belongsToMany(Group, {'as': 'Memberships', 'through': 'Group_Members'});
 
     /**
      * The organization unit (orgunit) model
@@ -467,8 +467,8 @@ var _setUpModel = function(sequelize) {
     Serie.belongsTo(Group);
     Group.hasMany(Serie);
 
-    OrgUnit.hasMany(Serie);
-    Serie.hasMany(OrgUnit);
+    OrgUnit.belongsToMany(Serie, {'through': 'OrgUnitsSeries'});
+    Serie.belongsToMany(OrgUnit, {'through': 'OrgUnitsSeries'});
 
     /**
      * The event model
@@ -559,11 +559,11 @@ var _setUpModel = function(sequelize) {
     Event.belongsTo(Group);
     Group.hasMany(Event);
 
-    Event.hasMany(User, {'as': 'Organisers', 'through': 'Event_Organisers'});
-    User.hasMany(Event, {'as': 'OrganisedEvents', 'through': 'Event_Organisers'});
+    Event.belongsToMany(User, {'as': 'Organisers', 'through': 'Event_Organisers'});
+    User.belongsToMany(Event, {'as': 'OrganisedEvents', 'through': 'Event_Organisers'});
 
-    Serie.hasMany(Event);
-    Event.hasMany(Serie);
+    Serie.belongsToMany(Event, {'through': 'EventsSeries'});
+    Event.belongsToMany(Serie, {'through': 'EventsSeries'});
 
     /**
      * The calendar model
@@ -601,8 +601,8 @@ var _setUpModel = function(sequelize) {
     User.hasOne(Calendar);
 
     // Allow for calendar.addSeries([])
-    Calendar.hasMany(Serie, {'through': CalendarSeries});
-    Serie.hasMany(Calendar, {'through': CalendarSeries});
+    Calendar.belongsToMany(Serie, {'through': CalendarSeries});
+    Serie.belongsToMany(Calendar, {'through': CalendarSeries});
 
     // Allow for calendar.find(.. include[CalendarSeries])
     Calendar.hasMany(CalendarSeries);
@@ -611,8 +611,8 @@ var _setUpModel = function(sequelize) {
     CalendarSeries.belongsTo(Serie);
 
     // Calendars can also have single events
-    Calendar.hasMany(Event);
-    Event.hasMany(Calendar);
+    Calendar.belongsToMany(Event, {'through': 'CalendarsEvents'});
+    Event.belongsToMany(Calendar, {'through': 'CalendarsEvents'});
 
     /**
      * The config model


### PR DESCRIPTION
> Using 2 x hasMany to represent N:M relations has been deprecated. Please use belongsToMany instead

We currently have a deprecation warning as Sequelize added a new method `belongsToMany`.
This is just a matter of using the correct `hasMany`  / `belongsToMany` combinations in `gh-core/lib/db.js`.