### PR TITLE
(Issue 102) Extend Sequelize.Promise to maintain callback pattern

### DIFF
--- a/node_modules/gh-core/lib/api.js
+++ b/node_modules/gh-core/lib/api.js
@@ -49,6 +49,10 @@ var appServer = module.exports.appServer = null;
  * @param  {Object}         callback.err        An error object, if any
  */
 var init = module.exports.init = function(config, callback) {
+
+    // Apply global helper utilities
+    require('./globals');
+
     // Initialize the logger
     Logger.refreshLogConfiguration(config.log);
 

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -45,9 +45,7 @@ var init = module.exports.init = function(config, callback) {
     // Set up a connection to the database
     sequelize = new Sequelize(config.db.database, config.db.username, config.db.password, config.db);
 
-    sequelize
-    .authenticate()
-    .done(function(err) {
+    sequelize.authenticate().complete(function(err) {
         if (err) {
             log().error({'err': err}, 'Unable to set up a connection to the database');
             return callback({'code': 500, 'msg': 'Unable to set up a connection to the database'});
@@ -70,17 +68,14 @@ var init = module.exports.init = function(config, callback) {
             force = true;
         }
 
-        sequelize
-        .sync({'force': force})
-        .done(function(err) {
+        sequelize.sync({'force': force}).complete(function(err) {
             if (err) {
                 log().error({'err': err}, 'Unable to sync the model to the database');
                 return callback({'code': 500, 'msg': 'Unable to sync the model to the database'});
             }
 
             log().debug('Synced model to database');
-
-            _setUpPubSub(sequelize, callback);
+            return _setUpPubSub(sequelize, callback);
         });
     });
 };

--- a/node_modules/gh-core/lib/globals.js
+++ b/node_modules/gh-core/lib/globals.js
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2015 "Fronteer LTD"
+ * Grasshopper Event Engine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Apply global sequelize helpers
+require('./globals/sequelize');

--- a/node_modules/gh-core/lib/globals/sequelize.js
+++ b/node_modules/gh-core/lib/globals/sequelize.js
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2015 "Fronteer LTD"
+ * Grasshopper Event Engine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var Promise = require('sequelize/lib/promise');
+
+/**
+ * Add a style helper to the sequelize Promise that allows us to use callback-style error handling
+ *
+ * @param  {Function}   callback        Standard callback function
+ * @param  {Object}     callback.err    An error that occurred, if any
+ * @param  {Args}       callback.arg0   A variable number of callback-specific return arguments
+ */
+Promise.prototype.complete = function(callback) {
+    this
+        // Success condition
+        .then(function() {
+            // Shift a null value as the first parameter in the callback to indicate the result is
+            // a success
+            var args = Array.prototype.slice.call(arguments);
+            args.unshift(null);
+            return callback.apply(null, args);
+        })
+
+        // Failure condition
+        .catch(function(err) {
+            // Send the err argument to the consumer as the first and only parameter
+            callback.call(null, err);
+        });
+};

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pg-hstore": "latest",
     "readdirp": "latest",
     "restjsdoc": "latest",
-    "sequelize": "2.0.6",
+    "sequelize": "latest",
     "validator": "1.1.3",
     "yargs": "latest"
   },


### PR DESCRIPTION
PR for #102

Note the `globals` pattern is one that I've also applied in (I think) the OAuth PR in order to pull in lodash mixins. They should be compatible.

Assigning to @simong for review / discussion on extending `Sequelize.Promise`