### PR TITLE
Handle catch before then

### DIFF
--- a/node_modules/gh-core/lib/globals/sequelize.js
+++ b/node_modules/gh-core/lib/globals/sequelize.js
@@ -18,6 +18,16 @@
 
 var Promise = require('sequelize/lib/promise');
 
+/*!
+ * If an unhandled error is thrown inside the promise, we should promote it. This is needed because
+ * if an unhandled exception occurs in the `callback` during the `then` handler it is considered a
+ * rejection. Since we want things like unit tests to catch these in the test domain, or express to
+ * catch exceptions in the error handling middlewhere, we will promote them
+ */
+Promise.onPossiblyUnhandledRejection(function(err) {
+    throw err;
+});
+
 /**
  * Add a style helper to the sequelize Promise that allows us to use callback-style error handling
  *
@@ -27,18 +37,21 @@ var Promise = require('sequelize/lib/promise');
  */
 Promise.prototype.complete = function(callback) {
     this
+
+        // Failure condition. This must be registered before the `then` condition to ensure that an
+        // error in the callback does not get caught by this handler, risking that the callback be
+        // invoked twice
+        .catch(function(err) {
+            // Send the err argument to the consumer as the first and only parameter
+            callback.call(null, err);
+        })
+
         // Success condition
         .then(function() {
             // Shift a null value as the first parameter in the callback to indicate the result is
             // a success
             var args = Array.prototype.slice.call(arguments);
             args.unshift(null);
-            return callback.apply(null, args);
-        })
-
-        // Failure condition
-        .catch(function(err) {
-            // Send the err argument to the consumer as the first and only parameter
-            callback.call(null, err);
+            callback.apply(null, args);
         });
 };


### PR DESCRIPTION
Something is loopy in our promise->callback wrapper. LITERALLY.

If an error is thrown in the success callback (e.g., an assert error in tests), then the `catch` handles it and re-invokes the callback.

This PR ensures that our catch handler doesn't handle callback errors, and they are instead promoted which is synonymous to our previous callback pattern.