### PR TITLE
Terms and Conditions

### DIFF
--- a/etc/migrations/termsAndConditions.sql
+++ b/etc/migrations/termsAndConditions.sql
@@ -1,0 +1,3 @@
+alter table "Configs" add "termsAndConditionsText" text default ''::text;
+alter table "Configs" add "termsAndConditionsEnabled" boolean default false;
+alter table "Configs" add "termsAndConditionsLastUpdate" timestamp with time zone;

--- a/node_modules/gh-apps/lib/api.js
+++ b/node_modules/gh-apps/lib/api.js
@@ -324,7 +324,7 @@ var getTermsAndConditions = module.exports.getTermsAndConditions = function(ctx,
             return callback(err);
         }
 
-        var termsAndConditions = _getTermsAndConditions(app.id);
+        var termsAndConditions = getTermsAndConditionsForApp(app);
         return callback(null, termsAndConditions);
     });
 };
@@ -332,19 +332,17 @@ var getTermsAndConditions = module.exports.getTermsAndConditions = function(ctx,
 /**
  * Get the Terms and Conditions for an application.
  *
- * This method performs no validation on the given application id and should only be used when
- * you're sure the application exists. It's only exported because some dependencies shouldn't incur
- * the overhead of an extra DB query that happens through `getTermsAndConditions`
+ * This method performs no validation on the given application and should only be used when
+ * you're sure the application exist
  *
- * @param  {Number}         id                              The id of the application for which to retrieve the terms and conditions
+ * @param  {App}            app                             The application for which to retrieve the terms and conditions
  * @return {Object}         termsAndConditions              The Terms and Conditions for the application
  * @throws {Error}                                          Error when the application does not exist
- * @api private
  */
-var _getTermsAndConditions = module.exports._getTermsAndConditions = function(id) {
+var getTermsAndConditionsForApp = module.exports.getTermsAndConditionsForApp = function(app) {
     return {
-        'text': ConfigAPI.config(id).termsAndConditionsText,
-        'enabled': ConfigAPI.config(id).termsAndConditionsEnabled,
-        'lastUpdate': ConfigAPI.config(id).termsAndConditionsLastUpdate
+        'text': ConfigAPI.config(app.id).termsAndConditionsText,
+        'enabled': ConfigAPI.config(app.id).termsAndConditionsEnabled,
+        'lastUpdate': ConfigAPI.config(app.id).termsAndConditionsLastUpdate
     };
 };

--- a/node_modules/gh-apps/lib/api.js
+++ b/node_modules/gh-apps/lib/api.js
@@ -18,6 +18,7 @@
 
 var _ = require('lodash');
 
+var ConfigAPI = require('gh-config');
 var GrasshopperUtil = require('gh-core/lib/util');
 var log = require('gh-core/lib/logger').logger('gh-apps');
 var TenantsAPI = require('gh-tenants');
@@ -73,7 +74,7 @@ var getApp = module.exports.getApp = function(ctx, id, callback) {
 
     // Validation
     var validator = new Validator();
-    validator.check(id, {'code': 400, 'msg': 'A valid tenant id must be provided'}).isInt();
+    validator.check(id, {'code': 400, 'msg': 'A valid app id must be provided'}).isInt();
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
     }
@@ -293,4 +294,57 @@ var updateAppAdmins = module.exports.updateAppAdmins = function(ctx, id, adminUp
             AppsDAO.updateAppAdmins(adminUpdates, callback);
         });
     });
+};
+
+/* Terms and Conditions */
+
+/**
+ * Get the Terms and Conditions for an application
+ *
+ * @param  {Context}        ctx                             Standard context containing the current user and the current app
+ * @param  {Number}         id                              The id of the application for which to retrieve the terms and conditions
+ * @param  {Function}       callback                        Standard callback function
+ * @param  {Object}         callback.err                    An error object, if any
+ * @param  {Object}         callback.termsAndConditions     The Terms and Conditions for the application
+ */
+var getTermsAndConditions = module.exports.getTermsAndConditions = function(ctx, id, callback) {
+    // Ensure that the app id is a valid number
+    id = GrasshopperUtil.getNumberParam(id);
+
+    // Validation
+    var validator = new Validator();
+    validator.check(id, {'code': 400, 'msg': 'A valid app id must be provided'}).isInt();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    // Verify that the provided application exists
+    getApp(ctx, id, function(err, app) {
+        if (err) {
+            return callback(err);
+        }
+
+        var termsAndConditions = _getTermsAndConditions(app.id);
+        return callback(null, termsAndConditions);
+    });
+};
+
+/**
+ * Get the Terms and Conditions for an application.
+ *
+ * This method performs no validation on the given application id and should only be used when
+ * you're sure the application exists. It's only exported because some dependencies shouldn't incur
+ * the overhead of an extra DB query that happens through `getTermsAndConditions`
+ *
+ * @param  {Number}         id                              The id of the application for which to retrieve the terms and conditions
+ * @return {Object}         termsAndConditions              The Terms and Conditions for the application
+ * @throws {Error}                                          Error when the application does not exist
+ * @api private
+ */
+var _getTermsAndConditions = module.exports._getTermsAndConditions = function(id) {
+    return {
+        'text': ConfigAPI.config(id).termsAndConditionsText,
+        'enabled': ConfigAPI.config(id).termsAndConditionsEnabled,
+        'lastUpdate': ConfigAPI.config(id).termsAndConditionsLastUpdate
+    };
 };

--- a/node_modules/gh-apps/lib/rest.js
+++ b/node_modules/gh-apps/lib/rest.js
@@ -184,5 +184,6 @@ var _getTermsAndConditions = function(req, res) {
         return res.status(200).send(termsAndConditions);
     });
 };
+
 GrassHopper.globalAdminRouter.on('get', '/api/apps/:id/termsAndConditions', _getTermsAndConditions);
 GrassHopper.appRouter.on('get', '/api/apps/:id/termsAndConditions', _getTermsAndConditions);

--- a/node_modules/gh-apps/lib/rest.js
+++ b/node_modules/gh-apps/lib/rest.js
@@ -163,3 +163,26 @@ var _updateAppAdmins = function(req, res) {
 
 GrassHopper.globalAdminRouter.on('post', '/api/apps/:id/admins', _updateAppAdmins);
 GrassHopper.appRouter.on('post', '/api/apps/:id/admins', _updateAppAdmins);
+
+/**
+ * @REST getTermsAndConditions
+ *
+ * Get the Terms and Conditions
+ *
+ * @Server      admin,app
+ * @Method      GET
+ * @Path        /apps/{id}/termsAndConditions
+ * @PathParam   {number}            id              The id of the app for which to get the Terms and Conditions
+ * @Return      {TermsAndConditions}                The Terms and Conditions for the app
+ */
+var _getTermsAndConditions = function(req, res) {
+    AppsAPI.getTermsAndConditions(req.ctx, req.params.id, function(err, termsAndConditions) {
+        if (err) {
+            return res.status(err.code).send(err.msg);
+        }
+
+        return res.status(200).send(termsAndConditions);
+    });
+};
+GrassHopper.globalAdminRouter.on('get', '/api/apps/:id/termsAndConditions', _getTermsAndConditions);
+GrassHopper.appRouter.on('get', '/api/apps/:id/termsAndConditions', _getTermsAndConditions);

--- a/node_modules/gh-apps/tests/util.js
+++ b/node_modules/gh-apps/tests/util.js
@@ -379,3 +379,40 @@ var assertUpdateAppAdminsFails = module.exports.assertUpdateAppAdminsFails = fun
         return callback();
     });
 };
+
+/**
+ * Assert that the Terms and Conditions for an application can be retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Number}             app                             The id of the app for which to get the Terms and Conditions
+ * @param  {Function}           callback                        Standard callback function
+ * @param  {Object}             callback.termsAndConditions     The Terms and Conditions
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetTermsAndConditions = module.exports.assertGetTermsAndConditions = function(client, app, callback) {
+    client.app.getTermsAndConditions(app, function(err, termsAndConditions) {
+        assert.ok(!err);
+        assert.ok(_.isObject(termsAndConditions));
+        assert.ok(_.isString(termsAndConditions.text));
+        assert.ok(_.isString(termsAndConditions.lastUpdate));
+        return callback(termsAndConditions);
+    });
+};
+
+/**
+ * Assert that the Terms and Conditions for an application can not be retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Number}             app                             The id of the app for which to get the Terms and Conditions
+ * @param  {Number}             code                            The expected HTTP error code
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetTermsAndConditionsFails = module.exports.assertGetTermsAndConditionsFails = function(client, app, code, callback) {
+    client.app.getTermsAndConditions(app, function(err, termsAndConditions) {
+        assert.ok(err);
+        assert.strictEqual(err.code, code);
+        assert.ok(!termsAndConditions);
+        return callback();
+    });
+};

--- a/node_modules/gh-config/lib/api.js
+++ b/node_modules/gh-config/lib/api.js
@@ -136,6 +136,7 @@ var _getSuppressedConfig = function(fullConfig) {
     delete suppressedConfig.shibMapDisplayname;
     delete suppressedConfig.shibMapEmail;
     delete suppressedConfig.statsd;
+    delete suppressedConfig.termsAndConditionsText;
 
     // Return the suppressed config object
     return suppressedConfig;
@@ -250,6 +251,11 @@ var updateConfig = module.exports.updateConfig = function(ctx, appId, update, ca
     });
     if (validator.hasErrors()) {
         return callback(validator.getFirstError());
+    }
+
+    // Keep track of when a Terms and Conditions value gets changed
+    if (_.has(update, 'termsAndConditionsEnabled') || _.has(update, 'termsAndConditionsText')) {
+        update.termsAndConditionsLastUpdate = new Date();
     }
 
     // Ensure the app exists

--- a/node_modules/gh-config/lib/internal/dao.js
+++ b/node_modules/gh-config/lib/internal/dao.js
@@ -25,7 +25,7 @@ var log = require('gh-core/lib/logger').logger('gh-config');
 var fields = ['allowLocalAccountCreation', 'enableLocalAuth', 'enableShibbolethAuth', 'shibIdpEntityId',
               'shibExternalIdAttributes', 'shibMapDisplayname', 'shibMapEmail', 'allowUserEventCreation',
               'allowUserSerieCreation', 'enableAnalytics', 'analyticsTrackingId', 'academicYear',
-              'statsd'];
+              'statsd', 'termsAndConditionsEnabled', 'termsAndConditionsText'];
 module.exports.EDITABLE_FIELDS = fields;
 
 /**

--- a/node_modules/gh-config/tests/util.js
+++ b/node_modules/gh-config/tests/util.js
@@ -44,6 +44,8 @@ var assertGetConfig = module.exports.assertGetConfig = function(client, appId, e
         assert.ok(_.has(config, 'enableShibbolethAuth'));
         assert.ok(_.has(config, 'enableAnalytics'));
         assert.ok(_.has(config, 'analyticsTrackingId'));
+        assert.ok(_.has(config, 'termsAndConditionsEnabled'));
+        assert.ok(_.has(config, 'termsAndConditionsLastUpdate'));
 
         if (expectSuppressed) {
             assert.ok(_.isUndefined(config.shibIdpEntityId));
@@ -51,12 +53,14 @@ var assertGetConfig = module.exports.assertGetConfig = function(client, appId, e
             assert.ok(_.isUndefined(config.shibMapDisplayname));
             assert.ok(_.isUndefined(config.shibMapEmail));
             assert.ok(_.isUndefined(config.statsd));
+            assert.ok(_.isUndefined(config.termsAndConditionsText));
         } else {
             assert.ok(_.has(config, 'shibIdpEntityId'));
             assert.ok(_.has(config, 'shibExternalIdAttributes'));
             assert.ok(_.has(config, 'shibMapDisplayname'));
             assert.ok(_.has(config, 'shibMapEmail'));
             assert.ok(_.has(config, 'statsd'));
+            assert.ok(_.has(config, 'termsAndConditionsText'));
         }
 
         return callback(config);

--- a/node_modules/gh-core/lib/api.js
+++ b/node_modules/gh-core/lib/api.js
@@ -174,6 +174,19 @@ var _initialiseExpressServers = function(config, callback) {
     // Initialize the Passport authentication strategies
     AuthAPI.init(config);
 
+    /*!
+     * Add middleware that will check if the user has accepted the Terms and Conditions, if enabled.
+     * If the user hasn't accepted the Terms and Conditions, all POST requests (excluding whitelisted post requests) will be prevented.
+     */
+    module.exports.appServer.use(function(req, res, next) {
+        // The Terms and Conditions middleware is only applicable on logged in users who
+        // try to interact with the system excluding a set of whitelisted endpoints
+        if (!_.contains(['GET', 'HEAD'], req.method) && UsersAPI.needsToAcceptTermsAndConditions(req.ctx) && !_isWhiteListed(req.path)) {
+            return res.status(419).send('You need to accept the Terms and Conditions before you can interact with this application');
+        }
+        return next();
+    });
+
     Server.postInitialize(module.exports.globalAdminServer, module.exports.globalAdminRouter);
     Server.postInitialize(module.exports.appServer, module.exports.appRouter);
 
@@ -191,4 +204,15 @@ var _initialiseExpressServers = function(config, callback) {
     _.each(ghModules, function(module) {
         DocsAPI.documentModule(module, moduleDocumented);
     });
+};
+
+/**
+ * Check if a URL is whitelisted from the Terms and Conditions requirements
+ *
+ * @param  {String}     url     The URL to check
+ * @return {Boolean}            `true` if the user doesn't have to accept the Terms and Conditions in order to POST to this url, `false` otherwise
+ * @api private
+ */
+var _isWhiteListed = function(url) {
+    return (url.indexOf('/api/auth') === 0 || url.indexOf('/api/users') === 0);
 };

--- a/node_modules/gh-core/lib/api.js
+++ b/node_modules/gh-core/lib/api.js
@@ -181,7 +181,7 @@ var _initialiseExpressServers = function(config, callback) {
     module.exports.appServer.use(function(req, res, next) {
         // The Terms and Conditions middleware is only applicable on logged in users who
         // try to interact with the system excluding a set of whitelisted endpoints
-        if (!_.contains(['GET', 'HEAD'], req.method) && UsersAPI.needsToAcceptTermsAndConditions(req.ctx) && !_isWhiteListed(req.path)) {
+        if (!_.contains(['GET', 'HEAD'], req.method) && UsersAPI.needsToAcceptTermsAndConditions(req.ctx) && _requiresTermsAndConditions(req.path)) {
             return res.status(419).send('You need to accept the Terms and Conditions before you can interact with this application');
         }
         return next();
@@ -207,12 +207,12 @@ var _initialiseExpressServers = function(config, callback) {
 };
 
 /**
- * Check if a URL is whitelisted from the Terms and Conditions requirements
+ * Check if a URL requires the Terms and Conditions to be accepted
  *
  * @param  {String}     url     The URL to check
- * @return {Boolean}            `true` if the user doesn't have to accept the Terms and Conditions in order to POST to this url, `false` otherwise
+ * @return {Boolean}            `true` if the user hasto accept the Terms and Conditions in order to POST to this url, `false` otherwise
  * @api private
  */
-var _isWhiteListed = function(url) {
-    return (url.indexOf('/api/auth') === 0 || url.indexOf('/api/users') === 0);
+var _requiresTermsAndConditions = function(url) {
+    return !(url.indexOf('/api/auth') === 0 || url.indexOf('/api/users') === 0);
 };

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -806,7 +806,7 @@ var _setUpModel = function(sequelize) {
      * @property {Boolean}      analyticsTrackingId                 The Segment.io analytics tracking identifier
      * @property {String}       academicYear                        The academic year for an application
      * @property {String}       statsd                              The ip, port and prefix that can be used to interact with statsd. Should be formatted as `ip:port:prefix`
-     * @property {String}       termsAndConditionsText              The terms and conditions for this page
+     * @property {String}       termsAndConditionsText              The terms and conditions for this application
      * @property {Boolean}      termsAndConditionsEnabled           Whether the terms and conditions for this application are enabled
      * @property {Date}         termsAndConditionsLastUpdate        The timestamp when the terms and conditions were last updated
      * @property {App}          app                                 The application with which the configuration is associated

--- a/node_modules/gh-core/lib/db.js
+++ b/node_modules/gh-core/lib/db.js
@@ -239,7 +239,10 @@ var _setUpModel = function(sequelize) {
             'type': Sequelize.STRING,
             'allowNull': true
         },
-        'termsAndConditions': Sequelize.DATE,
+        'termsAndConditions': {
+            'type': Sequelize.DATE,
+            'allowNull': true
+        },
         'calendarToken': {
             'type': Sequelize.STRING,
             'allowNull': false
@@ -803,6 +806,9 @@ var _setUpModel = function(sequelize) {
      * @property {Boolean}      analyticsTrackingId                 The Segment.io analytics tracking identifier
      * @property {String}       academicYear                        The academic year for an application
      * @property {String}       statsd                              The ip, port and prefix that can be used to interact with statsd. Should be formatted as `ip:port:prefix`
+     * @property {String}       termsAndConditionsText              The terms and conditions for this page
+     * @property {Boolean}      termsAndConditionsEnabled           Whether the terms and conditions for this application are enabled
+     * @property {Date}         termsAndConditionsLastUpdate        The timestamp when the terms and conditions were last updated
      * @property {App}          app                                 The application with which the configuration is associated
      */
     var Config = module.exports.Config = sequelize.define('Config', {
@@ -864,6 +870,20 @@ var _setUpModel = function(sequelize) {
         'statsd': {
             'type': Sequelize.STRING,
             'defaultValue': null,
+            'allowNull': true
+        },
+        'termsAndConditionsText': {
+            'type': Sequelize.TEXT,
+            'defaultValue': '',
+            'allowNull': true
+        },
+        'termsAndConditionsEnabled': {
+            'type': Sequelize.BOOLEAN,
+            'defaultValue': false,
+            'allowNull': true
+        },
+        'termsAndConditionsLastUpdate': {
+            'type': Sequelize.DATE,
             'allowNull': true
         },
         'AppId': {

--- a/node_modules/gh-rest/lib/rest/app.js
+++ b/node_modules/gh-rest/lib/rest/app.js
@@ -127,4 +127,19 @@ module.exports = function(client) {
         client._request(url, 'POST', adminUpdates, null, callback);
     };
 
+    /**
+     * Get the Terms and Conditions for an application
+     *
+     * @param  {Number}             app                             The id of the app for which to get the Terms and Conditions
+     * @param  {Function}           callback                        Standard callback function
+     * @param  {Object}             callback.err                    An error that occurred, if any
+     * @param  {Object}             callback.body                   The JSON response from the REST API
+     * @param  {Response}           callback.response               The response object as returned by requestjs
+     * @see gh-user/lib/rest.js for more information
+     */
+    client.app.getTermsAndConditions = function(app, callback) {
+        var url = '/api/apps/' + client.util.encodeURIComponent(app) + '/termsAndConditions';
+        client._request(url, 'GET', null, null, callback);
+    };
+
 };

--- a/node_modules/gh-rest/lib/rest/user.js
+++ b/node_modules/gh-rest/lib/rest/user.js
@@ -82,6 +82,7 @@ module.exports = function(client) {
      * @param  {Boolean}        [opts.isAdmin]                  Whether the user is an app administrator
      * @param  {String}         [opts.recaptchaChallenge]       The identifier for the recaptcha challenge. Only required when the current user is not an app administrator
      * @param  {String}         [opts.recaptchaResponse]        The recaptcha response entered for the presented challenge. Only required when the current user is not an app administrator
+     * @param  {Boolean}        [opts.termsAndConditions]       Whether the user accepts the Terms and Conditions
      * @param  {Function}       callback                        Standard callback function
      * @param  {Object}         callback.err                    An error that occurred, if any
      * @param  {Object}         callback.body                   The JSON response from the REST API
@@ -98,7 +99,8 @@ module.exports = function(client) {
             'emailPreference': opts.emailPreference,
             'isAdmin': opts.isAdmin,
             'recaptchaChallenge': opts.recaptchaChallenge,
-            'recaptchaResponse': opts.recaptchaResponse
+            'recaptchaResponse': opts.recaptchaResponse,
+            'termsAndConditions': opts.termsAndConditions
         };
         client._request('/api/users', 'POST', user, null, callback);
     };
@@ -136,6 +138,35 @@ module.exports = function(client) {
     client.user.updateAdminStatus = function(id, admin, callback) {
         var url = '/api/users/' + client.util.encodeURIComponent(id) + '/admin';
         client._request(url, 'POST', {'admin': admin}, null, callback);
+    };
+
+    /**
+     * Get the Terms and Conditions
+     *
+     * @param  {Function}           callback                        Standard callback function
+     * @param  {Object}             callback.err                    An error that occurred, if any
+     * @param  {Object}             callback.body                   The JSON response from the REST API
+     * @param  {Response}           callback.response               The response object as returned by requestjs
+     * @see gh-user/lib/rest.js for more information
+     */
+    client.user.getTermsAndConditions = function(callback) {
+        var url = '/api/termsAndConditions';
+        client._request(url, 'GET', null, null, callback);
+    };
+
+    /**
+     * Accept the Terms and Conditions
+     *
+     * @param  {Number}             id                              The id of the user to accept the Terms and Conditions
+     * @param  {Function}           callback                        Standard callback function
+     * @param  {Object}             callback.err                    An error that occurred, if any
+     * @param  {Object}             callback.body                   The JSON response from the REST API
+     * @param  {Response}           callback.response               The response object as returned by requestjs
+     * @see gh-user/lib/rest.js for more information
+     */
+    client.user.acceptTermsAndConditions = function(id, callback) {
+        var url = '/api/users/' + client.util.encodeURIComponent(id) + '/termsAndConditions';
+        client._request(url, 'POST', null, null, callback);
     };
 
     /**

--- a/node_modules/gh-rest/lib/rest/user.js
+++ b/node_modules/gh-rest/lib/rest/user.js
@@ -141,20 +141,6 @@ module.exports = function(client) {
     };
 
     /**
-     * Get the Terms and Conditions
-     *
-     * @param  {Function}           callback                        Standard callback function
-     * @param  {Object}             callback.err                    An error that occurred, if any
-     * @param  {Object}             callback.body                   The JSON response from the REST API
-     * @param  {Response}           callback.response               The response object as returned by requestjs
-     * @see gh-user/lib/rest.js for more information
-     */
-    client.user.getTermsAndConditions = function(callback) {
-        var url = '/api/termsAndConditions';
-        client._request(url, 'GET', null, null, callback);
-    };
-
-    /**
      * Accept the Terms and Conditions
      *
      * @param  {Number}             id                              The id of the user to accept the Terms and Conditions

--- a/node_modules/gh-users/lib/api.js
+++ b/node_modules/gh-users/lib/api.js
@@ -220,7 +220,7 @@ var createUser = module.exports.createUser = function(ctx, appId, userProfile, c
         }
 
         // Verify the user accepted the Terms and Conditions if there are any
-        var termsAndConditions = AppsAPI._getTermsAndConditions(app.id);
+        var termsAndConditions = AppsAPI.getTermsAndConditionsForApp(app);
         if (!isAdminApp && termsAndConditions.enabled && !userProfile.termsAndConditions) {
             return callback({'code': 400, 'msg': 'The Terms and Conditions need to be accepted'});
         }
@@ -818,7 +818,7 @@ var needsToAcceptTermsAndConditions = module.exports.needsToAcceptTermsAndCondit
         return false;
     }
 
-    var termsAndConditions = AppsAPI._getTermsAndConditions(ctx.app.id);
+    var termsAndConditions = AppsAPI.getTermsAndConditionsForApp(ctx.app);
 
     // If the Terms and Conditions have not been enabled, the user can't accept anything
     if (!termsAndConditions.enabled) {

--- a/node_modules/gh-users/lib/api.js
+++ b/node_modules/gh-users/lib/api.js
@@ -219,6 +219,11 @@ var createUser = module.exports.createUser = function(ctx, appId, userProfile, c
             return callback({'code': 401, 'msg': 'Local user accounts can not be created on this application'});
         }
 
+        // Verify the user accepted the Terms and Conditions if there are any
+        if (getTermsAndConditions(appId).enabled && !userProfile.termsAndConditions) {
+            return callback({'code': 400, 'msg': 'The Terms and Conditions need to be accepted'});
+        }
+
         // Ensure that a user with the provided credentials doesn't already exist
         UsersDAO.getUserByCredentials(appId, credentials.strategy, (credentials.shibbolethId || userProfile.email), function(err, user) {
             if (user) {
@@ -783,4 +788,107 @@ var resetUserCalendarToken = module.exports.resetUserCalendarToken = function(ct
 var _getCalendarInfo = function(ctx, user, format) {
     var link = util.format('https://%s/api/user/%s/%s/calendar.%s', ctx.app.host, user.id, user.calendarToken, format);
     return new CalendarInfo(ctx.app, user.displayName, '', ctx.app.displayName, link, '', user.updatedAt);
+};
+
+/* Terms and conditions */
+
+/**
+ * Get the Terms and Conditions for an application
+ *
+ * @param  {Number}    appId        The application for which to retrieve the terms and conditions
+ * @return {Object}                 The Terms and Conditions for the application
+ */
+var getTermsAndConditions = module.exports.getTermsAndConditions = function(appId) {
+    return {
+        'text': ConfigAPI.config(appId).termsAndConditionsText,
+        'enabled': ConfigAPI.config(appId).termsAndConditionsEnabled,
+        'lastUpdate': ConfigAPI.config(appId).termsAndConditionsLastUpdate
+    };
+};
+
+/**
+ * Get status of the Terms and Conditions for a user
+ *
+ * @param  {Context}    ctx         Standard context containing the current user and the current app
+ * @return {Oject}                  The status of the Terms and Conditions for the user
+ */
+var getTermsAndConditionsStatus = module.exports.getTermsAndConditionsStatus = function(ctx) {
+    return {
+        'accepted': (ctx.user) ? ctx.user.termsAndConditions : null,
+        'needsToAccept': needsToAcceptTermsAndConditions(ctx)
+    };
+};
+
+/**
+ * Check if a user needs to accept or re-accept the Terms and Conditions
+ *
+ * @param  {Context}    ctx         Standard context containing the current user and the current app
+ * @return {Boolean}                Whether or not the current user needs to accept or re-accept the Terms and Conditions
+ */
+var needsToAcceptTermsAndConditions = module.exports.needsToAcceptTermsAndConditions = function(ctx) {
+    // Anonymous users don't need to accept the Terms and Conditions
+    if (!ctx.user) {
+        return false;
+    }
+
+    var termsAndConditions = getTermsAndConditions(ctx.app.id);
+
+    // If the Terms and Conditions have not been enabled, the user can't accept anything
+    if (!termsAndConditions.enabled) {
+        return false;
+
+    // Administrators don't need to accept anything
+    } else if (ctx.user.canAdmin(ctx.app.id)) {
+        return false;
+    }
+
+    // This application has Terms and Conditions. We need to check the user has accepted
+    // the Terms and Conditions since the last time they were updated
+    return (!ctx.user.termsAndConditions || ctx.user.termsAndConditions < termsAndConditions.lastUpdate);
+};
+
+/**
+ * Accept the Terms and Conditions
+ *
+ * @param  {Context}    ctx                 Standard context containing the current user and the current app
+ * @param  {Number}     id                  The id of the user for which to accept the Terms and Conditions
+ * @param  {Function}   callback            Standard callback function
+ * @param  {Object}     callback.err        An error object, if any
+ * @param  {Object}     callback.status     The updated status of the Terms and Conditions for the user
+ */
+var acceptTermsAndConditions = module.exports.acceptTermsAndConditions = function(ctx, id, callback) {
+    // Ensure that the user id is a valid number
+    id = GrasshopperUtil.getNumberParam(id);
+
+    var validator = new Validator();
+    validator.check(null, {'code': 401, 'msg': 'Only authenticated users can accept the terms and conditions'}).isLoggedInUser(ctx);
+    validator.check(id, {'code': 400, 'msg': 'A valid user id must be provided'}).isInt();
+    if (validator.hasErrors()) {
+        return callback(validator.getFirstError());
+    }
+
+    // Ensure the user exists
+    UsersDAO.getUser(id, function(err, user) {
+        if (err) {
+            return callback(err);
+        }
+
+        // Ensure the current user can accept the terms and conditions for the user
+        UsersAuthz.canAcceptTermsAndConditions(ctx, user, function(err, canAcceptTermsAndConditions) {
+            if (err) {
+                return callback(err);
+            } else if (!canAcceptTermsAndConditions) {
+                log().warn({'id': id, 'actor': ctx.user.id}, 'Unauthorized attempt at accepting the terms and conditions for a user');
+                return callback({'code': 401, 'msg': 'You are not allowed to accept the terms and conditions for a user'});
+            }
+
+            UsersDAO.updateUser(user, {'termsAndConditions': Date.now()}, function(err) {
+                if (err) {
+                    return callback(err);
+                }
+                ctx.user = user;
+                return callback(null, getTermsAndConditionsStatus(ctx));
+            });
+        });
+    });
 };

--- a/node_modules/gh-users/lib/api.js
+++ b/node_modules/gh-users/lib/api.js
@@ -220,7 +220,8 @@ var createUser = module.exports.createUser = function(ctx, appId, userProfile, c
         }
 
         // Verify the user accepted the Terms and Conditions if there are any
-        if (getTermsAndConditions(appId).enabled && !userProfile.termsAndConditions) {
+        var termsAndConditions = AppsAPI._getTermsAndConditions(app.id);
+        if (!isAdminApp && termsAndConditions.enabled && !userProfile.termsAndConditions) {
             return callback({'code': 400, 'msg': 'The Terms and Conditions need to be accepted'});
         }
 
@@ -233,7 +234,7 @@ var createUser = module.exports.createUser = function(ctx, appId, userProfile, c
                 return callback(err);
             }
 
-            UsersDAO.createUser(appId, userProfile, credentials, callback);
+            return UsersDAO.createUser(appId, userProfile, credentials, callback);
         });
     });
 };
@@ -793,20 +794,6 @@ var _getCalendarInfo = function(ctx, user, format) {
 /* Terms and conditions */
 
 /**
- * Get the Terms and Conditions for an application
- *
- * @param  {Number}    appId        The application for which to retrieve the terms and conditions
- * @return {Object}                 The Terms and Conditions for the application
- */
-var getTermsAndConditions = module.exports.getTermsAndConditions = function(appId) {
-    return {
-        'text': ConfigAPI.config(appId).termsAndConditionsText,
-        'enabled': ConfigAPI.config(appId).termsAndConditionsEnabled,
-        'lastUpdate': ConfigAPI.config(appId).termsAndConditionsLastUpdate
-    };
-};
-
-/**
  * Get status of the Terms and Conditions for a user
  *
  * @param  {Context}    ctx         Standard context containing the current user and the current app
@@ -831,7 +818,7 @@ var needsToAcceptTermsAndConditions = module.exports.needsToAcceptTermsAndCondit
         return false;
     }
 
-    var termsAndConditions = getTermsAndConditions(ctx.app.id);
+    var termsAndConditions = AppsAPI._getTermsAndConditions(ctx.app.id);
 
     // If the Terms and Conditions have not been enabled, the user can't accept anything
     if (!termsAndConditions.enabled) {

--- a/node_modules/gh-users/lib/authz.js
+++ b/node_modules/gh-users/lib/authz.js
@@ -78,6 +78,24 @@ var canResetUserToken = module.exports.canResetUserToken = function(ctx, user, c
 };
 
 /**
+ * Determine whether or not the user in context can accept the Terms and Conditions for a user
+ *
+ * @param  {Context}    ctx                                         Standard context object containing the current user and the current application
+ * @param  {User}       user                                        The user to accept the Terms and Conditions for
+ * @param  {Function}   callback                                    Standard callback function
+ * @param  {Object}     callback.err                                An error that occurred, if any
+ * @param  {Boolean}    callback.canAcceptTermsAndConditions        `true` if the user in context has the appropriate permission. `false` otherwise
+ */
+var canAcceptTermsAndConditions = module.exports.canAcceptTermsAndConditions = function(ctx, user, callback) {
+    if (!ctx.user) {
+        return callback(null, false);
+    }
+
+    var canAccept = (ctx.user.id === user.id);
+    return callback(null, canAccept);
+};
+
+/**
  * Determine whether or not the user in context can get a user's calendar
  *
  * @param  {Context}    ctx                         Standard context object containing the current user and the current application

--- a/node_modules/gh-users/lib/rest.js
+++ b/node_modules/gh-users/lib/rest.js
@@ -107,6 +107,7 @@ GrassHopper.appRouter.on('get', '/api/me', function(req, res) {
     if (req.ctx.user) {
         me = _.extend(me, {'anon': false}, req.ctx.user.toJSON());
     }
+    me = _.extend(me, {'termsAndConditions': UsersAPI.getTermsAndConditionsStatus(req.ctx)});
     res.status(200).send(me);
 });
 
@@ -239,11 +240,12 @@ GrassHopper.appRouter.on('get', '/api/users/:id/upcoming', _getUserUpcoming);
  *
  * @Server      app
  * @Method      GET
- * @Path        /users/termsAndConditions
+ * @Path        /termsAndConditions
  * @Return      {TermsAndConditions}                        The Terms and Conditions for the current app
  */
-GrassHopper.appRouter.on('get', '/api/users/termsAndConditions', function(req, res) {
-    res.sendStatus(501);
+GrassHopper.appRouter.on('get', '/api/termsAndConditions', function(req, res) {
+    var termsAndConditions = UsersAPI.getTermsAndConditions(req.ctx.app.id);
+    return res.status(200).send(termsAndConditions);
 });
 
 /**
@@ -254,11 +256,17 @@ GrassHopper.appRouter.on('get', '/api/users/termsAndConditions', function(req, r
  * @Server      app
  * @Method      POST
  * @Path        /users/{id}/termsAndConditions
- * @PathParam   {string}            id                      The id of the user for which to accept the Terms and Conditions on the current app
+ * @PathParam   {number}            id                      The id of the user for which to accept the Terms and Conditions on the current app
  * @Return      {TermsAndConditionsStatus}                  The updated status of the Terms and Conditions for the user on the current app
  */
 GrassHopper.appRouter.on('post', '/api/users/:id/termsAndConditions', function(req, res) {
-    res.sendStatus(501);
+    UsersAPI.acceptTermsAndConditions(req.ctx, req.params.id, function(err, termsAndConditionsStatus) {
+        if (err) {
+            return res.status(err.code).send(err.msg);
+        }
+
+        return res.status(200).send(termsAndConditionsStatus);
+    });
 });
 
 /**
@@ -277,6 +285,10 @@ var _createUser = function(req, res, appId) {
         'emailPreference': req.body.emailPreference,
         'isAdmin': req.body.isAdmin
     };
+    if (req.body.termsAndConditions === 'true') {
+        userProfile.termsAndConditions = new Date();
+    }
+
     // Extract the authentication credentials. The email address
     // will be used as the username
     var credentials = {

--- a/node_modules/gh-users/lib/rest.js
+++ b/node_modules/gh-users/lib/rest.js
@@ -105,9 +105,9 @@ GrassHopper.appRouter.on('get', '/api/me', function(req, res) {
         'app': req.ctx.app
     };
     if (req.ctx.user) {
-        me = _.extend(me, {'anon': false}, req.ctx.user.toJSON());
+        _.extend(me, {'anon': false}, req.ctx.user.toJSON());
     }
-    me = _.extend(me, {'termsAndConditions': UsersAPI.getTermsAndConditionsStatus(req.ctx)});
+    _.extend(me, {'termsAndConditions': UsersAPI.getTermsAndConditionsStatus(req.ctx)});
     res.status(200).send(me);
 });
 

--- a/node_modules/gh-users/lib/rest.js
+++ b/node_modules/gh-users/lib/rest.js
@@ -234,21 +234,6 @@ GrassHopper.globalAdminRouter.on('get', '/api/users/:id/upcoming', _getUserUpcom
 GrassHopper.appRouter.on('get', '/api/users/:id/upcoming', _getUserUpcoming);
 
 /**
- * @REST getTermsAndConditions
- *
- * Get the Terms and Conditions
- *
- * @Server      app
- * @Method      GET
- * @Path        /termsAndConditions
- * @Return      {TermsAndConditions}                        The Terms and Conditions for the current app
- */
-GrassHopper.appRouter.on('get', '/api/termsAndConditions', function(req, res) {
-    var termsAndConditions = UsersAPI.getTermsAndConditions(req.ctx.app.id);
-    return res.status(200).send(termsAndConditions);
-});
-
-/**
  * @REST acceptTermsAndConditions
  *
  * Accept the Terms and Conditions

--- a/node_modules/gh-users/tests/test-terms-and-conditions.js
+++ b/node_modules/gh-users/tests/test-terms-and-conditions.js
@@ -19,7 +19,10 @@
 var _ = require('lodash');
 var assert = require('assert');
 
+var AppsTestsUtil = require('gh-apps/tests/util');
+var AuthTestsUtil = require('gh-auth/tests/util');
 var ConfigTestsUtil = require('gh-config/tests/util');
+var RestAPI = require('gh-rest');
 var SeriesTestsUtil = require('gh-series/tests/util');
 var TestsUtil = require('gh-tests/lib/util');
 
@@ -49,9 +52,18 @@ describe('Terms and Conditions', function() {
                     // Set some Terms and Conditions
                     TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
                         var configuration = {
-                            'allowLocalAccountCreation': true,
                             'termsAndConditionsEnabled': true,
-                            'termsAndConditionsText': 'Oh lawdy'
+                            'termsAndConditionsText': 'Oh lawdy',
+
+                            // Allow local accounts to be created
+                            'allowLocalAccountCreation': true,
+
+                            // Enable Shibboleth authentication
+                            'enableShibbolethAuth': true,
+                            'shibIdpEntityId': 'https://idp.olympia.edu/shibboleth',
+                            'shibExternalIdAttributes': 'eppn persistent-id targeted-id',
+                            'shibMapDisplayname': 'displayname cn',
+                            'shibMapEmail': 'mail email eppn'
                         };
                         ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
                             return callback(tenant, app, globalAdminClient, simon, nico);
@@ -102,7 +114,7 @@ describe('Terms and Conditions', function() {
             setup(function(tenant, app, globalAdminClient, simon) {
 
                 // When the user tries to do anything, they need to accept the Terms and Conditions
-                SeriesTestsUtil.assertCreateSerieFails(simon.client, 'Test serie', null, 419, function() {
+                SeriesTestsUtil.assertCreateSerieFails(simon.client, 'Test series', null, 419, function() {
 
                     // Verify the me feed confirms that we need to accept the Terms and Conditions
                     UsersTestsUtil.assertGetMe(simon.client, function(me) {
@@ -116,7 +128,7 @@ describe('Terms and Conditions', function() {
                                 assert.strictEqual(me.termsAndConditions.needsToAccept, false);
 
                                 // Verify we can interact with the system
-                                SeriesTestsUtil.assertCreateSerie(simon.client, 'Test serie', null, function() {
+                                SeriesTestsUtil.assertCreateSerie(simon.client, 'Test series', null, function() {
 
                                     // Update the Terms and Conditions
                                     var configuration = {
@@ -142,21 +154,39 @@ describe('Terms and Conditions', function() {
          * Test that verifies that anonymous users don't need to accept the Terms and Conditions
          */
         it('verify anonymous users don\'t need to accept the Terms and Conditions', function(callback) {
-            TestsUtil.generateTestTenant(1, function(tenant, app) {
+            setup(function(tenant, app, globalAdminClient, simon) {
 
-                // Set some Terms and Conditions
-                TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
-                    var configuration = {
-                        'termsAndConditionsEnabled': true,
-                        'termsAndConditionsText': 'Oh lawdy'
-                    };
-                    ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+                // Verify anonymous users do not have to accept them
+                TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
+                    UsersTestsUtil.assertGetMe(anonymousClient, function(me) {
+                        assert.strictEqual(me.termsAndConditions.needsToAccept, false);
 
-                        // Verify anonymous users do not have to accept them
-                        TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
-                            UsersTestsUtil.assertGetMe(anonymousClient, function(me) {
-                                assert.strictEqual(me.termsAndConditions.needsToAccept, false);
-                                return callback();
+                        // Verify anonymous users can still do POST requests to start the authentication workflows
+                        var options = {
+                            'host': TestsUtil.getAppListenUri(),
+                            'hostHeader': app.host,
+                            'authenticationStrategy': 'local',
+                            'username': simon.profile.email,
+                            'password': simon.client.options.password
+                        };
+                        RestAPI.createClient(options, function(err, authenticatedClient) {
+                            assert.ok(!err);
+                            UsersTestsUtil.assertGetMe(authenticatedClient, function(me) {
+                                assert.ok(!me.anon);
+                                assert.strictEqual(me.termsAndConditions.needsToAccept, true);
+
+                                // Verify Shibboleth authentication still works
+                                var attributes = {
+                                    'email': TestsUtil.generateTestEmailAddress(),
+                                    'displayname': 'Simon G'
+                                };
+                                AuthTestsUtil.assertShibbolethLogin(app, null, attributes, null, function(restClient, remoteUser) {
+                                    UsersTestsUtil.assertGetMe(restClient, function(me) {
+                                        assert.ok(!me.anon);
+
+                                        return callback();
+                                    });
+                                });
                             });
                         });
                     });
@@ -165,13 +195,13 @@ describe('Terms and Conditions', function() {
         });
 
         /**
-         * Test that verifies that admininistrators don't need to accept the Terms and Conditions to
+         * Test that verifies that administrators don't need to accept the Terms and Conditions to
          * interact with an application
          */
         it('verify administrators don\'t need to accept the Terms and Conditions', function(callback) {
             setup(function(tenant, app, globalAdminClient, simon) {
                 // When the user tries to do anything, they need to accept the Terms and Conditions
-                SeriesTestsUtil.assertCreateSerieFails(simon.client, 'Test serie', null, 419, function() {
+                SeriesTestsUtil.assertCreateSerieFails(simon.client, 'Test series', null, 419, function() {
 
                     // Verify the me feed confirms that we need to accept the Terms and Conditions
                     UsersTestsUtil.assertGetMe(simon.client, function(me) {
@@ -181,7 +211,7 @@ describe('Terms and Conditions', function() {
                         UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, simon.profile.id, true, function() {
 
                             // Simon should now be able to create series
-                            SeriesTestsUtil.assertCreateSerie(simon.client, 'Test serie', null, function() {
+                            SeriesTestsUtil.assertCreateSerie(simon.client, 'Test series', null, function() {
 
                                 // Verify the me feed confirms that we don't need to accept the Terms and Conditions
                                 UsersTestsUtil.assertGetMe(simon.client, function(me) {
@@ -190,6 +220,61 @@ describe('Terms and Conditions', function() {
                                     return callback();
                                 });
                             });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Assert that users created by administrators still need to verify the Terms and Conditions
+         *
+         * @param  {RestClient}     client          A REST client that can administrate the application
+         * @param  {App}            app             The application to create a user on
+         * @param  {Function}       callback        Standard callback function
+         */
+        var assertCreateUser = function(client, app, callback) {
+            // Assert that global admins can create local user accounts
+            var email = TestsUtil.generateTestEmailAddress();
+            UsersTestsUtil.assertCreateUser(client, 'displayName', email, 'password', {'app': app.id}, function(user) {
+
+                // Create a REST client for the created user
+                var options = {
+                    'host': TestsUtil.getAppListenUri(),
+                    'hostHeader': app.host,
+                    'authenticationStrategy': 'local',
+                    'username': email,
+                    'password': 'password'
+                };
+                RestAPI.createClient(options, function(err, client) {
+                    assert.ok(!err);
+
+                    // Assert the user still needs to accept the T&C
+                    UsersTestsUtil.assertGetMe(client, function(me) {
+                        assert.strictEqual(me.termsAndConditions.accepted, null);
+                        assert.ok(me.termsAndConditions.needsToAccept);
+                        return callback();
+                    });
+                });
+            });
+        };
+
+        /**
+         * Test that verifies that administrators don't need to accept the Terms and Conditions when
+         * creating an account for another user
+         */
+        it('verify administrators don\'t need to accept the Terms and Conditions when creating an account for another user', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon) {
+
+                // Assert global administrators can create user accounts that still need to accept the T&C
+                assertCreateUser(globalAdminClient, app, function() {
+
+                    // Make Simon an application administrator
+                    UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, simon.profile.id, true, function() {
+
+                        // Assert application administrators can create user accounts that still need to accept the T&C
+                        assertCreateUser(simon.client, app, function() {
+                            return callback();
                         });
                     });
                 });
@@ -248,6 +333,25 @@ describe('Terms and Conditions', function() {
     describe('Getting the Terms and Conditions', function() {
 
         /**
+         * Test that verifies validation when getting the Terms and Conditions
+         */
+        it('verify validation when getting the Terms and Conditions', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon, nico) {
+
+                // Invalid application id
+                AppsTestsUtil.assertGetTermsAndConditionsFails(simon.client, 'invalid', 400, function() {
+
+                    // Unknown application id
+                    AppsTestsUtil.assertGetTermsAndConditionsFails(simon.client, -1, 404, function() {
+                        AppsTestsUtil.assertGetTermsAndConditionsFails(simon.client, 32423423, 404, function() {
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
          * Test that verifies authorization when getting the Terms and Conditions
          */
         it('verify authorization when getting the Terms and Conditions', function(callback) {
@@ -255,13 +359,20 @@ describe('Terms and Conditions', function() {
 
                 // Everyone should be able to get the Terms and Conditions
                 TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
-                    UsersTestsUtil.assertGetTermsAndConditions(anonymousClient, function(termsAndConditions) {
+                    AppsTestsUtil.assertGetTermsAndConditions(anonymousClient, app.id, function(termsAndConditions) {
+                        TestsUtil.getAnonymousGlobalAdminRestClient(function(anonymousGlobalAdminClient) {
+                            AppsTestsUtil.assertGetTermsAndConditions(anonymousGlobalAdminClient, app.id, function(termsAndConditions) {
 
-                        UsersTestsUtil.assertGetTermsAndConditions(simon.client, function(termsAndConditions) {
+                                AppsTestsUtil.assertGetTermsAndConditions(simon.client, app.id, function(termsAndConditions) {
 
-                            UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, nico.profile.id, true, function() {
-                                UsersTestsUtil.assertGetTermsAndConditions(nico.client, function(termsAndConditions) {
-                                    return callback();
+                                    UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, nico.profile.id, true, function() {
+                                        AppsTestsUtil.assertGetTermsAndConditions(nico.client, app.id, function(termsAndConditions) {
+
+                                            AppsTestsUtil.assertGetTermsAndConditions(globalAdminClient, app.id, function(termsAndConditions) {
+                                                return callback();
+                                            });
+                                        });
+                                    });
                                 });
                             });
                         });
@@ -277,18 +388,22 @@ describe('Terms and Conditions', function() {
             setup(function(tenant, app, globalAdminClient, simon, nico) {
 
                 // Get the Terms and Conditions
-                UsersTestsUtil.assertGetTermsAndConditions(simon.client, function(termsAndConditions) {
+                AppsTestsUtil.assertGetTermsAndConditions(simon.client, app.id, function(termsAndConditions) {
 
-                    // Update the Terms and Conditions
-                    var configuration = {'termsAndConditionsText': 'Oh heavens no'};
-                    ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+                    // Add an artificial time-out so we don't run into test failures when the 2 T&C updates happen within the same millisecond
+                    setTimeout(function() {
 
-                        // Get the updated Terms and Conditions
-                        UsersTestsUtil.assertGetTermsAndConditions(simon.client, function(updatedTermsAndConditions) {
-                            assert.ok(updatedTermsAndConditions.lastUpdate > termsAndConditions.lastUpdate);
-                            return callback();
+                        // Update the Terms and Conditions
+                        var configuration = {'termsAndConditionsText': 'Oh heavens no'};
+                        ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+
+                            // Get the updated Terms and Conditions
+                            AppsTestsUtil.assertGetTermsAndConditions(simon.client, app.id, function(updatedTermsAndConditions) {
+                                assert.ok(updatedTermsAndConditions.lastUpdate > termsAndConditions.lastUpdate);
+                                return callback();
+                            });
                         });
-                    });
+                    }, 100);
                 });
             });
         });

--- a/node_modules/gh-users/tests/test-terms-and-conditions.js
+++ b/node_modules/gh-users/tests/test-terms-and-conditions.js
@@ -1,0 +1,296 @@
+/**
+ * Copyright (c) 2015 "Fronteer LTD"
+ * Grasshopper Event Engine
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+var _ = require('lodash');
+var assert = require('assert');
+
+var ConfigTestsUtil = require('gh-config/tests/util');
+var SeriesTestsUtil = require('gh-series/tests/util');
+var TestsUtil = require('gh-tests/lib/util');
+
+var UsersTestsUtil = require('gh-users/tests/util');
+
+describe('Terms and Conditions', function() {
+
+    /**
+     * Create a tenant and application that contains 2 users and has an enabled Terms and Conditions
+     *
+     * @param  {Function}       callback                            Standard callback function
+     * @param  {Tenant}         callback.tenant                     The created tenant
+     * @param  {App}            callback.app                        The created application
+     * @param  {RestClient}     callback.globalAdminClient          A global admin rest client
+     * @param  {Object}         callback.user1                      A regular user in the application
+     * @param  {Object}         callback.user2                      A regular user in the application
+     * @api private
+     */
+    var setup = function(callback) {
+        TestsUtil.generateTestTenant(1, function(tenant, app) {
+            TestsUtil.generateTestUsers(app, 2, false, function(simon, nico) {
+
+                // Sanity-check that the application has no Terms and Conditions
+                UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                    assert.strictEqual(me.termsAndConditions.needsToAccept, false);
+
+                    // Set some Terms and Conditions
+                    TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+                        var configuration = {
+                            'allowLocalAccountCreation': true,
+                            'termsAndConditionsEnabled': true,
+                            'termsAndConditionsText': 'Oh lawdy'
+                        };
+                        ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+                            return callback(tenant, app, globalAdminClient, simon, nico);
+                        });
+                    });
+                });
+            });
+        });
+    };
+
+    describe('System interaction', function() {
+
+        /**
+         * Test that verifies that user need to accept the Terms and Conditions when creating an account
+         */
+        it('verify users need to accept the Terms and Conditions when creating an account', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon) {
+
+                TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
+                    var email = TestsUtil.generateTestEmailAddress();
+                    UsersTestsUtil.assertCreateUserFails(anonymousClient, 'displayName', email, 'password', {}, 400, function() {
+                        UsersTestsUtil.assertCreateUserFails(anonymousClient, 'displayName', email, 'password', {'termsAndConditions': 'not true'}, 400, function() {
+                            UsersTestsUtil.assertCreateUserFails(anonymousClient, 'displayName', email, 'password', {'termsAndConditions': false}, 400, function() {
+
+                                // Check a user can be created if the Terms and Conditions are accepted
+                                UsersTestsUtil.assertCreateUser(anonymousClient, 'displayName', email, 'password', {'termsAndConditions': true}, function() {
+
+                                    // Sanity check users can be created without specifying the `termsAndConditions` option
+                                    // if the Terms and Conditions are disabled
+                                    ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, {'termsAndConditionsEnabled': false}, function() {
+                                        var email2 = TestsUtil.generateTestEmailAddress();
+                                        UsersTestsUtil.assertCreateUser(anonymousClient, 'displayName', email2, 'password', {}, function() {
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that users cannot interact with the system when a Terms and Conditions comes into effect
+         */
+        it('verify regular users need to accept the Terms and Conditions before they can interact with the system', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon) {
+
+                // When the user tries to do anything, they need to accept the Terms and Conditions
+                SeriesTestsUtil.assertCreateSerieFails(simon.client, 'Test serie', null, 419, function() {
+
+                    // Verify the me feed confirms that we need to accept the Terms and Conditions
+                    UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                        assert.strictEqual(me.termsAndConditions.needsToAccept, true);
+
+                        // Accept the Terms and Conditions
+                        UsersTestsUtil.assertAcceptTermsAndConditions(simon.client, simon.profile.id, function() {
+
+                            // Verify the me feed confirms that we don't need to accept the Terms and Conditions anymore
+                            UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                                assert.strictEqual(me.termsAndConditions.needsToAccept, false);
+
+                                // Verify we can interact with the system
+                                SeriesTestsUtil.assertCreateSerie(simon.client, 'Test serie', null, function() {
+
+                                    // Update the Terms and Conditions
+                                    var configuration = {
+                                        'termsAndConditionsText': 'Oh heavens no'
+                                    };
+                                    ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+
+                                        // Verify the user needs to re-accept the Terms and Conditions
+                                        UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                                            assert.strictEqual(me.termsAndConditions.needsToAccept, true);
+                                            return callback();
+                                        });
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that anonymous users don't need to accept the Terms and Conditions
+         */
+        it('verify anonymous users don\'t need to accept the Terms and Conditions', function(callback) {
+            TestsUtil.generateTestTenant(1, function(tenant, app) {
+
+                // Set some Terms and Conditions
+                TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
+                    var configuration = {
+                        'termsAndConditionsEnabled': true,
+                        'termsAndConditionsText': 'Oh lawdy'
+                    };
+                    ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+
+                        // Verify anonymous users do not have to accept them
+                        TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
+                            UsersTestsUtil.assertGetMe(anonymousClient, function(me) {
+                                assert.strictEqual(me.termsAndConditions.needsToAccept, false);
+                                return callback();
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies that admininistrators don't need to accept the Terms and Conditions to
+         * interact with an application
+         */
+        it('verify administrators don\'t need to accept the Terms and Conditions', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon) {
+                // When the user tries to do anything, they need to accept the Terms and Conditions
+                SeriesTestsUtil.assertCreateSerieFails(simon.client, 'Test serie', null, 419, function() {
+
+                    // Verify the me feed confirms that we need to accept the Terms and Conditions
+                    UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                        assert.strictEqual(me.termsAndConditions.needsToAccept, true);
+
+                        // Make Simon an application administrator
+                        UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, simon.profile.id, true, function() {
+
+                            // Simon should now be able to create series
+                            SeriesTestsUtil.assertCreateSerie(simon.client, 'Test serie', null, function() {
+
+                                // Verify the me feed confirms that we don't need to accept the Terms and Conditions
+                                UsersTestsUtil.assertGetMe(simon.client, function(me) {
+                                    assert.strictEqual(me.termsAndConditions.needsToAccept, false);
+
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Accepting', function() {
+
+        /**
+         * Test that verifies validation when accepting the Terms and Conditions
+         */
+        it('verify validation when accepting the Terms and Conditions', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon) {
+
+                UsersTestsUtil.assertAcceptTermsAndConditionsFails(simon.client, 'not a number', 400, function() {
+                    UsersTestsUtil.assertAcceptTermsAndConditionsFails(simon.client, -1, 404, function() {
+                        UsersTestsUtil.assertAcceptTermsAndConditionsFails(simon.client, 32423423, 404, function() {
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies authorization when accepting the Terms and Conditions
+         */
+        it('verify authorization when accepting the Terms and Conditions', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon, nico) {
+
+                // Anonymous user can't accept Terms and Conditions
+                TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
+                    UsersTestsUtil.assertAcceptTermsAndConditionsFails(anonymousClient, simon.profile.id, 401, function() {
+
+                        // Regular users can't accept the Terms and Conditions of another user
+                        UsersTestsUtil.assertAcceptTermsAndConditionsFails(nico.client, simon.profile.id, 401, function() {
+
+                            // Even application administrators shouldn't be able to force-accept
+                            // the Terms and Conditions of another user
+                            UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, nico.profile.id, true, function() {
+                                UsersTestsUtil.assertAcceptTermsAndConditionsFails(nico.client, simon.profile.id, 401, function() {
+
+                                    // We can't test global administrators as the endpoint is not exposed
+                                    // on the global administration server
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    });
+
+    describe('Getting the Terms and Conditions', function() {
+
+        /**
+         * Test that verifies authorization when getting the Terms and Conditions
+         */
+        it('verify authorization when getting the Terms and Conditions', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon, nico) {
+
+                // Everyone should be able to get the Terms and Conditions
+                TestsUtil.getAnonymousAppUserClient(app, function(anonymousClient) {
+                    UsersTestsUtil.assertGetTermsAndConditions(anonymousClient, function(termsAndConditions) {
+
+                        UsersTestsUtil.assertGetTermsAndConditions(simon.client, function(termsAndConditions) {
+
+                            UsersTestsUtil.assertUpdateAdminStatus(globalAdminClient, nico.profile.id, true, function() {
+                                UsersTestsUtil.assertGetTermsAndConditions(nico.client, function(termsAndConditions) {
+                                    return callback();
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+
+        /**
+         * Test that verifies the lastUpdate changes when the Terms and Conditions are changed
+         */
+        it('verify the lastUpdate timestamp changes after updating the Terms and Conditions', function(callback) {
+            setup(function(tenant, app, globalAdminClient, simon, nico) {
+
+                // Get the Terms and Conditions
+                UsersTestsUtil.assertGetTermsAndConditions(simon.client, function(termsAndConditions) {
+
+                    // Update the Terms and Conditions
+                    var configuration = {'termsAndConditionsText': 'Oh heavens no'};
+                    ConfigTestsUtil.assertUpdateConfig(globalAdminClient, app.id, configuration, function() {
+
+                        // Get the updated Terms and Conditions
+                        UsersTestsUtil.assertGetTermsAndConditions(simon.client, function(updatedTermsAndConditions) {
+                            assert.ok(updatedTermsAndConditions.lastUpdate > termsAndConditions.lastUpdate);
+                            return callback();
+                        });
+                    });
+                });
+            });
+        });
+    });
+});

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -18,6 +18,7 @@
 
 var _ = require('lodash');
 var assert = require('assert');
+var moment = require('moment');
 
 var TestsUtil = require('gh-tests/lib/util');
 
@@ -118,6 +119,7 @@ var assertGetMeEquals = module.exports.assertGetMeEquals = function(client, expe
  * @param  {Boolean}            [options.isAdmin]               Whether the user is an app administrator
  * @param  {String}             [options.recaptchaChallenge]    The identifier for the recaptcha challenge. Only required when the current user is not an app administrator
  * @param  {String}             [options.recaptchaResponse]     The recaptcha response entered for the presented challenge. Only required when the current user is not an app administrator
+ * @param  {Boolean}            [options.termsAndConditions]    Whether the user accepts the Terms and Conditions
  * @param  {Function}           callback                        Standard callback function
  * @param  {Object}             callback.user                   The basic user profile of the created test user
  */
@@ -147,6 +149,7 @@ var assertCreateUser = module.exports.assertCreateUser = function(client, displa
  * @param  {Boolean}            [options.isAdmin]               Whether the user is an app administrator
  * @param  {String}             [options.recaptchaChallenge]    The identifier for the recaptcha challenge. Only required when the current user is not an app administrator
  * @param  {String}             [options.recaptchaResponse]     The recaptcha response entered for the presented challenge. Only required when the current user is not an app administrator
+ * @param  {Boolean}            [options.termsAndConditions]    Whether the user accepts the Terms and Conditions
  * @param  {Number}             code                            The expected HTTP error code
  * @param  {Function}           callback                        Standard callback function
  * @throws {AssertionError}                                     Error thrown when an assertion failed
@@ -334,6 +337,63 @@ var assertGetUsersFails = module.exports.assertGetUsersFails = function(client, 
         assert.strictEqual(err.code, code);
         assert.ok(!users);
         return callback(users);
+    });
+};
+
+/**
+ * Assert that the Terms and Conditions can be retrieved
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Function}           callback                        Standard callback function
+ * @param  {Object}             callback.termsAndConditions     The Terms and Conditions
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertGetTermsAndConditions = module.exports.assertGetTermsAndConditions = function(client, callback) {
+    client.user.getTermsAndConditions(function(err, termsAndConditions) {
+        assert.ok(!err);
+        assert.ok(termsAndConditions);
+        assert.ok(termsAndConditions.text);
+        assert.ok(termsAndConditions.lastUpdate);
+        return callback(termsAndConditions);
+    });
+};
+
+/**
+ * Assert that a user can accept the Terms and Conditions
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Number}             id                              The id of the user for which to accept the Terms and Conditions
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertAcceptTermsAndConditions = module.exports.assertAcceptTermsAndConditions = function(client, id, callback) {
+    var start = moment();
+    client.user.acceptTermsAndConditions(id, function(err, termsAndConditionsStatus) {
+        assert.ok(!err);
+        assert.ok(termsAndConditionsStatus);
+        assert.ok(termsAndConditionsStatus.accepted);
+        var accepted = moment(termsAndConditionsStatus.accepted);
+        assert.ok(accepted.diff(start) > 0);
+        assert.strictEqual(termsAndConditionsStatus.needsToAccept, false);
+        return callback();
+    });
+};
+
+/**
+ * Assert that a user cannot accept the Terms and Conditions
+ *
+ * @param  {RestClient}         client                          The REST client to make the request with
+ * @param  {Number}             id                              The id of the user for which to accept the Terms and Conditions
+ * @param  {Number}             code                            The expected HTTP error code
+ * @param  {Function}           callback                        Standard callback function
+ * @throws {AssertionError}                                     Error thrown when an assertion failed
+ */
+var assertAcceptTermsAndConditionsFails = module.exports.assertAcceptTermsAndConditionsFails = function(client, id, code, callback) {
+    client.user.acceptTermsAndConditions(id, function(err, termsAndConditionsStatus) {
+        assert.ok(err);
+        assert.strictEqual(err.code, code);
+        assert.ok(!termsAndConditionsStatus);
+        return callback();
     });
 };
 

--- a/node_modules/gh-users/tests/util.js
+++ b/node_modules/gh-users/tests/util.js
@@ -341,24 +341,6 @@ var assertGetUsersFails = module.exports.assertGetUsersFails = function(client, 
 };
 
 /**
- * Assert that the Terms and Conditions can be retrieved
- *
- * @param  {RestClient}         client                          The REST client to make the request with
- * @param  {Function}           callback                        Standard callback function
- * @param  {Object}             callback.termsAndConditions     The Terms and Conditions
- * @throws {AssertionError}                                     Error thrown when an assertion failed
- */
-var assertGetTermsAndConditions = module.exports.assertGetTermsAndConditions = function(client, callback) {
-    client.user.getTermsAndConditions(function(err, termsAndConditions) {
-        assert.ok(!err);
-        assert.ok(termsAndConditions);
-        assert.ok(termsAndConditions.text);
-        assert.ok(termsAndConditions.lastUpdate);
-        return callback(termsAndConditions);
-    });
-};
-
-/**
  * Assert that a user can accept the Terms and Conditions
  *
  * @param  {RestClient}         client                          The REST client to make the request with
@@ -367,15 +349,34 @@ var assertGetTermsAndConditions = module.exports.assertGetTermsAndConditions = f
  * @throws {AssertionError}                                     Error thrown when an assertion failed
  */
 var assertAcceptTermsAndConditions = module.exports.assertAcceptTermsAndConditions = function(client, id, callback) {
-    var start = moment();
-    client.user.acceptTermsAndConditions(id, function(err, termsAndConditionsStatus) {
-        assert.ok(!err);
-        assert.ok(termsAndConditionsStatus);
-        assert.ok(termsAndConditionsStatus.accepted);
-        var accepted = moment(termsAndConditionsStatus.accepted);
-        assert.ok(accepted.diff(start) > 0);
-        assert.strictEqual(termsAndConditionsStatus.needsToAccept, false);
-        return callback();
+    // Get the user profile so we can check whether the timestamp when they accepted
+    // the Terms and Conditions gets updated
+    assertGetUser(client, id, function(user) {
+        // Default the start timestamp to the current timestamp. This happens when a user hasn't
+        // accepted the Terms and Conditions before
+        var start = user.termsAndConditions || moment();
+
+        // Introduce an artificial delay to avoid intermittent test failures
+        setTimeout(function() {
+
+            // Accept the Terms and Conditions
+            client.user.acceptTermsAndConditions(id, function(err, termsAndConditionsStatus) {
+                assert.ok(!err);
+                assert.ok(_.isObject(termsAndConditionsStatus));
+                assert.ok(_.isString(termsAndConditionsStatus.accepted));
+                assert.strictEqual(termsAndConditionsStatus.needsToAccept, false);
+                TestsUtil.assertTimestamp(termsAndConditionsStatus.accepted, {
+                    'after': start
+                });
+
+                // Assert that the timestamp of when the Terms and Conditions were accepted
+                // are persisted on the user profile
+                assertGetUser(client, id, function(user) {
+                    assert.strictEqual(user.termsAndConditions, termsAndConditionsStatus.accepted);
+                    return callback();
+                });
+            });
+        }, 5);
     });
 };
 


### PR DESCRIPTION
I cleaned this up and rebased it against master. This allows application/global administrators to configure a terms and conditions.

Note that this needs the following migrations:
```
alter table "Configs" add "termsAndConditionsText" text default ''::text;
alter table "Configs" add "termsAndConditionsEnabled" boolean default false;
alter table "Configs" add "termsAndConditionsLastUpdate" timestamp with time zone;
```

and requires this commit to retain a functioning UI:
https://github.com/fronteerio/grasshopper-ui/commit/f6142de484f1f223c0f0c3555000181582304d20