### PR TITLE
Remove email matching from user search

### DIFF
--- a/node_modules/gh-users/lib/internal/dao.js
+++ b/node_modules/gh-users/lib/internal/dao.js
@@ -142,24 +142,32 @@ var searchUsers = module.exports.searchUsers = function(appId, query, limit, off
     limit = limit || 10;
     offset = offset || 0;
 
-    var sequelize = DB.getSequelize();
-
-    // Construct a query that selects a set of rows in the Users table ordered
-    // on the sum of the displayName and shibbolethId similarities. Although
-    // this isn't perfect, it gives a reasonable approximation of a typeahead search as
-    // each of the three columns their values are split up in possible trigrams and indexed
-    var sqlQuery = 'SELECT "Users".* ';
-    sqlQuery += 'FROM "Users" ';
-    sqlQuery += 'WHERE "AppId" = ? and ("displayName" <-> ? < 0.8 or "shibbolethId" <-> ? < 0.8) ';
-    sqlQuery += 'ORDER BY (("displayName" <-> ?) + ("shibbolethId" <-> ?)) asc ';
-    sqlQuery += 'LIMIT ? OFFSET ? ';
-
     var options = {
-        'replacements': [appId, query, query, query, query, limit, offset],
-        'type': 'SELECT',
-        'model': DB.User
+        'where': {
+            'AppId': appId,
+            '$or': [
+                {
+                    // Do a full text match on the display name. We can't do prefix matching here
+                    // as the display name column could contains strings such as `J. Donaldson` and
+                    // users might search for `Don`
+                    'displayName': {
+                        '$iLike': '%' + query + '%'
+                    }
+                },
+                {
+                    // It's unlikely to search for anything other than a prefix when matching on
+                    // Shibboleth IDs so we just do a prefix-search
+                    'shibbolethId': {
+                        '$iLike': query + '%'
+                    }
+                }
+            ]
+        },
+        'order': [['displayName', 'ASC']],
+        'limit': limit,
+        'offset': offset
     };
-    sequelize.query(sqlQuery, options).complete(function(err, users) {
+    DB.User.findAll(options).complete(function(err, users) {
         if (err) {
             log().error({'err': err, 'filter': query}, 'Unable to search on users');
             return callback({'code': 500, 'msg': 'Unable to search on users'});

--- a/node_modules/gh-users/lib/internal/dao.js
+++ b/node_modules/gh-users/lib/internal/dao.js
@@ -145,20 +145,17 @@ var searchUsers = module.exports.searchUsers = function(appId, query, limit, off
     var sequelize = DB.getSequelize();
 
     // Construct a query that selects a set of rows in the Users table ordered
-    // on the sum of the displayName, email and shibbolethId similarities. Although
+    // on the sum of the displayName and shibbolethId similarities. Although
     // this isn't perfect, it gives a reasonable approximation of a typeahead search as
-    // each of the three columns their values are split up in possible trigrams and indexed.
-    // We need to coalesce the `email` and `shibbolethId` columns as you can't get a similarity
-    // value from a null value. Because of the index on each column, the query itself is
-    // reasonably quick and accurate
+    // each of the three columns their values are split up in possible trigrams and indexed
     var sqlQuery = 'SELECT "Users".* ';
     sqlQuery += 'FROM "Users" ';
-    sqlQuery += 'WHERE "AppId" = ? ';
-    sqlQuery += 'ORDER BY (similarity("displayName", ?) + similarity(coalesce("email", ?), ?) + similarity(coalesce("shibbolethId", ?), ?)) DESC, "displayName" ASC, "id" ASC ';
-    sqlQuery += 'LIMIT ? OFFSET ?' ;
-    var coalescedValue = '';
+    sqlQuery += 'WHERE "AppId" = ? and ("displayName" <-> ? < 0.8 or "shibbolethId" <-> ? < 0.8) ';
+    sqlQuery += 'ORDER BY (("displayName" <-> ?) + ("shibbolethId" <-> ?)) asc ';
+    sqlQuery += 'LIMIT ? OFFSET ? ';
+
     var options = {
-        'replacements': [appId, query, coalescedValue, query, coalescedValue, query, limit, offset],
+        'replacements': [appId, query, query, query, query, limit, offset],
         'type': 'SELECT',
         'model': DB.User
     };

--- a/node_modules/gh-users/tests/test-search.js
+++ b/node_modules/gh-users/tests/test-search.js
@@ -113,13 +113,24 @@ describe('Users - Search', function() {
                             // Generate another user who will search for the shibboleth user
                             TestsUtil.generateTestUsers(app, 1, false, function(otherUser) {
 
-                                UsersTestsUtil.assertGetUsers(otherUser.client, null, shibUser.shibbolethId, 50, null, function(users) {
+                                // Search on a prefix of the shibboleth id
+                                var prefix = shibUser.shibbolethId.substring(0, 4);
+                                UsersTestsUtil.assertGetUsers(otherUser.client, null, prefix, 50, null, function(users) {
                                     var searchUser = _.find(users.results, {'id': shibUser.id});
                                     assert.ok(searchUser);
 
                                     // Assert the shibboleth id is returned
                                     assert.strictEqual(searchUser.shibbolethId, shibUser.shibbolethId);
-                                    return callback();
+
+                                    // Search on a full shibboleth id
+                                    UsersTestsUtil.assertGetUsers(otherUser.client, null, shibUser.shibbolethId, 50, null, function(users) {
+                                        var searchUser = _.find(users.results, {'id': shibUser.id});
+                                        assert.ok(searchUser);
+
+                                        // Assert the shibboleth id is returned
+                                        assert.strictEqual(searchUser.shibbolethId, shibUser.shibbolethId);
+                                        return callback();
+                                    });
                                 });
                             });
                         });

--- a/node_modules/gh-users/tests/test-search.js
+++ b/node_modules/gh-users/tests/test-search.js
@@ -41,9 +41,9 @@ describe('Users - Search', function() {
         TestsUtil.generateTestUsers(app, 3, false, function(jack, william, shirley) {
 
             // Update the display names and email addresses
-            UsersTestsUtil.assertUpdateUser(jack.client, jack.profile.id, {'displayName': 'Jack Daniels', 'email': 'jd123_' + _.random(100000) + '@example.com'}, function() {
-                UsersTestsUtil.assertUpdateUser(william.client, william.profile.id, {'displayName': 'William Lawson', 'email': 'wl4567_' + _.random(100000) + '@example.com'}, function() {
-                    UsersTestsUtil.assertUpdateUser(shirley.client, shirley.profile.id, {'displayName': 'Shirley Temple', 'email': 'st789_' + _.random(100000) + '@example.com'}, function() {
+            UsersTestsUtil.assertUpdateUser(jack.client, jack.profile.id, {'displayName': 'Jack Daniels similarity', 'email': 'jd123_' + _.random(100000) + '@example.com'}, function() {
+                UsersTestsUtil.assertUpdateUser(william.client, william.profile.id, {'displayName': 'William Lawson similarity', 'email': 'wl4567_' + _.random(100000) + '@example.com'}, function() {
+                    UsersTestsUtil.assertUpdateUser(shirley.client, shirley.profile.id, {'displayName': 'Shirley Temple similarity', 'email': 'st789_' + _.random(100000) + '@example.com'}, function() {
                         return callback(jack, william, shirley);
                     });
                 });
@@ -58,41 +58,7 @@ describe('Users - Search', function() {
         _setup(global.tests.apps.cam2013, function(jack, william, shirley) {
 
             // Search for 'jac'
-            UsersTestsUtil.assertGetUsers(global.tests.admins.cam2013.client, null, 'jac', 50, null, function(users) {
-                assert.ok(users.results.length > 0);
-
-                // Get the index of our three users in the results
-                var jackIndex = _.findIndex(users.results, {'id': jack.profile.id});
-                var williamIndex = _.findIndex(users.results, {'id': william.profile.id});
-                var shirleyIndex = _.findIndex(users.results, {'id': shirley.profile.id});
-
-                // Because the endpoint only returns x number of users, The "William Lawson" and "Shirley Temple"
-                // user might not get returned. Default the index value to a really high number, so we can more easily
-                // reason about them
-                jackIndex = (jackIndex === -1) ? Number.MAX_VALUE : jackIndex;
-                williamIndex = (williamIndex === -1) ? Number.MAX_VALUE : williamIndex;
-                shirleyIndex = (shirleyIndex === -1) ? Number.MAX_VALUE : shirleyIndex;
-
-                // Verify the "Jack Daniels" user is returned
-                assert.ok(jackIndex > -1);
-                assert.ok(jackIndex < Number.MAX_VALUE);
-
-                // Verify he is returned before the other two users
-                assert.ok(jackIndex < williamIndex);
-                assert.ok(jackIndex < shirleyIndex);
-                return callback();
-            });
-        });
-    });
-
-    /**
-     * Test that verifies that users can be queried on their email address
-     */
-    it('verify users can be queried on their email address', function(callback) {
-        _setup(global.tests.apps.cam2013, function(jack, william, shirley) {
-
-            // Search for 'jd123' which is the start of Jack's email address
-            UsersTestsUtil.assertGetUsers(global.tests.admins.cam2013.client, null, 'jd', 50, null, function(users) {
+            UsersTestsUtil.assertGetUsers(global.tests.admins.cam2013.client, null, 'jack', 50, null, function(users) {
                 assert.ok(users.results.length > 0);
 
                 // Get the index of our three users in the results
@@ -173,12 +139,12 @@ describe('Users - Search', function() {
 
                 // Get the first 2 users
                 TestsUtil.getGlobalAdminRestClient(function(globalAdminClient) {
-                    UsersTestsUtil.assertGetUsers(globalAdminClient, app.id, 'i', 2, 0, function(firstPage) {
+                    UsersTestsUtil.assertGetUsers(globalAdminClient, app.id, 'similarity', 2, 0, function(firstPage) {
                         assert.strictEqual(firstPage.results.length, 2);
                         var firstPageById = _.indexBy(firstPage.results, 'id');
 
                         // Get the third user
-                        UsersTestsUtil.assertGetUsers(globalAdminClient, app.id, 'i', 2, 2, function(secondPage) {
+                        UsersTestsUtil.assertGetUsers(globalAdminClient, app.id, 'similarity', 2, 2, function(secondPage) {
                             assert.strictEqual(secondPage.results.length, 1);
 
                             // Assert the user from the second page is not returned in the first page's results


### PR DESCRIPTION
This is a stop-gap measure to try and reduce the time a query takes. More investigation/potentially alternative solutions will follow soon.